### PR TITLE
[fix] missing argument

### DIFF
--- a/query.go
+++ b/query.go
@@ -686,7 +686,7 @@ func (q *Query) ExecCtx(ctx context.Context) *Iterator {
 
 // ExecToJson will execute query, and return iterator
 func (q *Query) ExecToJson(jsonRoots ...string) *JSONIterator {
-	return q.ExecToJsonCtx(context.Background())
+	return q.ExecToJsonCtx(context.Background(), jsonRoots...)
 }
 
 // ExecToJsonCtx will execute query, and return iterator


### PR DESCRIPTION
Fix ExecToJson method of Query struct doesn't pass jsonRoots argument down to ExecToJsonCtx method call