### PR TITLE
Fix deserialization of an ExpressionTypeSubQuery as a left expression produces incorrect error

### DIFF
--- a/cpp_src/core/query/expression/expression.cc
+++ b/cpp_src/core/query/expression/expression.cc
@@ -23,7 +23,8 @@ ExpressionValue Expression::Deserialize(Serializer& ser) {
 			return functions::Function::Deserialize(ser);
 		}
 		case ExpressionTypeSubQuery: {
-			return Query::Deserialize(ser);
+			Serializer subQuery{ser.GetVString()};
+			return Query::Deserialize(subQuery);
 		}
 		default:
 			throw Error{errParams, "Error deserializing expression: type ({}) is not supported"};

--- a/query.go
+++ b/query.go
@@ -318,7 +318,7 @@ func (q SubQuery) Type() int {
 
 func (s SubQuery) Serialize(ser *cjson.Serializer) {
 	ser.PutVarCUInt(int(s.Type()))
-	ser.Write(s.SubQuery.ser.Bytes())
+	ser.PutVBytes(s.SubQuery.ser.Bytes())
 }
 
 var queryPool sync.Pool


### PR DESCRIPTION
Closes gh-92