### PR TITLE
Uzer 007

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,25 +18,11 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
-          $url = "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.11/nsis-3.11.zip"
-          $archive = Join-Path $env:RUNNER_TEMP "nsis-3.11.zip"
-          $installDir = Join-Path $env:RUNNER_TEMP "nsis"
-          $expectedHash = "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1"
-
-          Invoke-WebRequest -Uri $url -OutFile $archive -MaximumRedirection 10
-
-          $actualHash = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
-          if ($actualHash -ne $expectedHash) {
-            throw "NSIS checksum mismatch. Expected $expectedHash, got $actualHash"
+          choco install nsis.portable --version=3.11.0 --yes --no-progress
+          if ($LASTEXITCODE -ne 0) {
+            throw "Chocolatey failed to install nsis.portable"
           }
-
-          Expand-Archive -Path $archive -DestinationPath $installDir -Force
-          $nsisPath = Join-Path $installDir "nsis-3.11"
-          if (!(Test-Path (Join-Path $nsisPath "makensis.exe"))) {
-            throw "makensis.exe was not found in $nsisPath"
-          }
-
-          $nsisPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          makensis /VERSION
       - name: Build Reindexer
         run: |
           mkdir build && cd build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,28 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
       - name: Install NSIS
-        uses: repolevedavaj/install-nsis@v1.1.0
-        with:
-          nsis-version: '3.11'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $url = "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.11/nsis-3.11.zip"
+          $archive = Join-Path $env:RUNNER_TEMP "nsis-3.11.zip"
+          $installDir = Join-Path $env:RUNNER_TEMP "nsis"
+          $expectedHash = "c7d27f780ddb6cffb4730138cd1591e841f4b7edb155856901cdf5f214394fa1"
+
+          Invoke-WebRequest -Uri $url -OutFile $archive -MaximumRedirection 10
+
+          $actualHash = (Get-FileHash $archive -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualHash -ne $expectedHash) {
+            throw "NSIS checksum mismatch. Expected $expectedHash, got $actualHash"
+          }
+
+          Expand-Archive -Path $archive -DestinationPath $installDir -Force
+          $nsisPath = Join-Path $installDir "nsis-3.11"
+          if (!(Test-Path (Join-Path $nsisPath "makensis.exe"))) {
+            throw "makensis.exe was not found in $nsisPath"
+          }
+
+          $nsisPath | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Build Reindexer
         run: |
           mkdir build && cd build

--- a/bindings.go
+++ b/bindings.go
@@ -43,8 +43,9 @@ func (db *reindexerImpl) modifyItem(ctx context.Context, namespace string, ns *r
 
 		format := 0
 		stateToken := 0
+		itemIsPtr := false
 
-		if format, stateToken, err = packItem(ns, item, nil, ser); err != nil {
+		if format, stateToken, itemIsPtr, err = packItem(ns, item, nil, ser); err != nil {
 			return
 		}
 
@@ -73,7 +74,7 @@ func (db *reindexerImpl) modifyItem(ctx context.Context, namespace string, ns *r
 
 		resultp := rdSer.readRawtItemParams(rawQueryParams.shardId)
 
-		if len(precepts) > 0 && (resultp.cptr != 0 || resultp.data != nil) && reflect.TypeOf(item).Kind() == reflect.Pointer {
+		if len(precepts) > 0 && (resultp.cptr != 0 || resultp.data != nil) && itemIsPtr {
 			nsArrEntry := nsArrayEntry{ns, ns.cjsonState.Copy()}
 			if _, err := unpackItem(db.binding, &nsArrEntry, &rawQueryParams, &resultp, false, true, item); err != nil {
 				return 0, err
@@ -85,7 +86,7 @@ func (db *reindexerImpl) modifyItem(ctx context.Context, namespace string, ns *r
 	return 0, err
 }
 
-func packItem(ns *reindexerNamespace, item any, json []byte, ser *cjson.Serializer) (format int, stateToken int, err error) {
+func packItem(ns *reindexerNamespace, item any, json []byte, ser *cjson.Serializer) (format int, stateToken int, itemIsPtr bool, err error) {
 	if item != nil {
 		json, _ = item.([]byte)
 	}
@@ -93,10 +94,13 @@ func packItem(ns *reindexerNamespace, item any, json []byte, ser *cjson.Serializ
 	if json == nil {
 		t := reflect.TypeOf(item)
 		if t.Kind() == reflect.Pointer {
+			itemIsPtr = true
 			t = t.Elem()
 		}
-		if ns.rtype.Name() != t.Name() || ns.rtype.PkgPath() != t.PkgPath() {
-			panic(ErrWrongType)
+		if t != ns.rtype {
+			if ns.rtype.Name() != t.Name() || ns.rtype.PkgPath() != t.PkgPath() {
+				panic(ErrWrongType)
+			}
 		}
 
 		format = bindings.FormatCJson

--- a/bindings/cproto/encdec.go
+++ b/bindings/cproto/encdec.go
@@ -167,7 +167,7 @@ func (r *rpcDecoder) intfArg() any {
 	case bindings.ValueInt:
 		return int(r.ser.GetVarInt())
 	case bindings.ValueBool:
-		return r.ser.GetVarInt() != 0
+		return r.ser.GetVarUInt() != 0
 	case bindings.ValueString:
 		return r.ser.GetVBytes()
 	case bindings.ValueInt64:

--- a/cjson/creflect.go
+++ b/cjson/creflect.go
@@ -194,7 +194,7 @@ func (pl *payloadIface) ptr(field, idx, typ int) unsafe.Pointer {
 const hexChars = "0123456789abcdef"
 
 func createUuid(v [2]uint64) string {
-	buf := make([]byte, 36)
+	var buf [36]byte
 	buf[0] = hexChars[(v[0]>>60)&0xF]
 	buf[1] = hexChars[(v[0]>>56)&0xF]
 	buf[2] = hexChars[(v[0]>>52)&0xF]
@@ -231,7 +231,7 @@ func createUuid(v [2]uint64) string {
 	buf[33] = hexChars[(v[1]>>8)&0xF]
 	buf[34] = hexChars[(v[1]>>4)&0xF]
 	buf[35] = hexChars[v[1]&0xF]
-	return string(buf)
+	return string(buf[:])
 }
 
 func (pl *payloadIface) getInt(field, idx int) int {

--- a/cjson/ctagscache.go
+++ b/cjson/ctagscache.go
@@ -64,13 +64,7 @@ func (tc *ctagsWCache) Reset() {
 	(*tc) = (*tc)[:0]
 }
 
-func (tc *ctagsWCache) Lookup(idx []int) *ctagsWCacheEntry {
-	if len(idx) == 0 {
-		return &ctagsWCacheEntry{}
-	}
-
-	field := idx[0]
-
+func (tc *ctagsWCache) LookupField(field int) *ctagsWCacheEntry {
 	if len(*tc) <= field {
 		if cap(*tc) <= field {
 			nc := make([]ctagsWCacheEntry, len(*tc), field+1)
@@ -81,9 +75,19 @@ func (tc *ctagsWCache) Lookup(idx []int) *ctagsWCacheEntry {
 			(*tc) = append((*tc), ctagsWCacheEntry{})
 		}
 	}
-	if len(idx) == 1 {
-		return &(*tc)[field]
+	return &(*tc)[field]
+}
+
+func (tc *ctagsWCache) Lookup(idx []int) *ctagsWCacheEntry {
+	if len(idx) == 0 {
+		return &ctagsWCacheEntry{}
 	}
 
-	return (*tc)[field].subCache.Lookup(idx[1:])
+	field := idx[0]
+	entry := tc.LookupField(field)
+	if len(idx) == 1 {
+		return entry
+	}
+
+	return entry.subCache.Lookup(idx[1:])
 }

--- a/cjson/decoder.go
+++ b/cjson/decoder.go
@@ -116,7 +116,7 @@ func skipTag(rdser *Serializer, tagType int16) {
 		rdser.GetVarUInt()
 	case TAG_NULL:
 	case TAG_STRING:
-		rdser.GetVString()
+		rdser.SkipVString()
 	case TAG_UUID:
 		rdser.GetUuid()
 	case TAG_FLOAT:
@@ -207,7 +207,7 @@ func asIface(rdser *Serializer, tagType int16) any {
 	case TAG_DOUBLE:
 		return rdser.GetDouble()
 	case TAG_BOOL:
-		return rdser.GetVarInt() != 0
+		return rdser.GetVarUInt() != 0
 	case TAG_STRING:
 		return rdser.GetVString()
 	case TAG_NULL:

--- a/cjson/encoder.go
+++ b/cjson/encoder.go
@@ -126,21 +126,41 @@ func parseStructField(sf reflect.StructField) (name string, skip, omitEmpty bool
 
 func (enc *Encoder) encodeStruct(v reflect.Value, rdser *Serializer, cache *ctagsWCache) error {
 	t := v.Type()
-	for field := 0; field < v.NumField(); field++ {
-		var ce *ctagsWCacheEntry
-		if cache == nil {
-			// if cache is null - we have top level interface field,
-			// in this case we can have any untyped data in deep, so
-			// ctagsCache 'name path' -> type will not work
-			// So here is using slow path: use reflect to obtain info about each field
-			ce = &ctagsWCacheEntry{}
-		} else {
-			// We have not interface fields on top level, so using cache
-			ce = cache.LookupField(field)
-		}
+	numField := v.NumField()
+	var entries []ctagsWCacheEntry
+	if cache != nil {
+		entries = *cache
+	}
+	for field := range numField {
+		if cache != nil {
+			// We have not interface fields on top level, so using cache.
+			if field < len(entries) {
+				ce := &entries[field]
+				if ce.ctagName != 0 || ce.isPrivate {
+					if !ce.isPrivate {
+						// process field, except private unexported fields
+						err := enc.encodeValue(v.Field(field), rdser, ce.fieldInfo, &ce.subCache)
+						if err != nil {
+							return err
+						}
+					}
+					continue
+				}
+			}
 
-		if ce.ctagName == 0 && !ce.isPrivate {
-			// No data in cache: use reflect to get data about field
+			ce := cache.LookupField(field)
+			if ce.ctagName != 0 || ce.isPrivate {
+				if !ce.isPrivate {
+					// process field, except private unexported fields
+					err := enc.encodeValue(v.Field(field), rdser, ce.fieldInfo, &ce.subCache)
+					if err != nil {
+						return err
+					}
+				}
+				continue
+			}
+
+			// No data in cache: use reflect to get data about field.
 			vv := v.Field(field)
 			f := t.Field(field)
 			name, skip, omitempty := parseStructField(f)
@@ -148,23 +168,41 @@ func (enc *Encoder) encodeStruct(v reflect.Value, rdser *Serializer, cache *ctag
 			if !skip {
 				ctagName = enc.name2tag(name)
 			}
-			if enc.tmUpdated {
-				// if tagsMatcher or lock is updated - we have temporary tags, do not cache them
-				ce = &ctagsWCacheEntry{}
-			}
 
-			ce.fieldInfo = mkFieldInfo(vv, ctagName, f)
-			ce.isPrivate = len(f.PkgPath) != 0 || skip
-			ce.isOmitEmpty = omitempty
+			fi := mkFieldInfo(vv, ctagName, f)
+			fi.isPrivate = len(f.PkgPath) != 0 || skip
+			fi.isOmitEmpty = omitempty
+
+			var subCache *ctagsWCache
+			if !enc.tmUpdated {
+				ce.fieldInfo = fi
+				if !fi.isPrivate {
+					subCache = &ce.subCache
+				}
+			}
+			if !fi.isPrivate {
+				// process field, except private unexported fields
+				err := enc.encodeValue(v.Field(field), rdser, fi, subCache)
+				if err != nil {
+					return err
+				}
+			}
+			continue
 		}
 
-		if !ce.isPrivate {
-			var subCache *ctagsWCache
-			if cache != nil {
-				subCache = &ce.subCache
-			}
-			// process field, except private unexported fields
-			err := enc.encodeValue(v.Field(field), rdser, ce.fieldInfo, subCache)
+		// Top-level interface field: use slow path, because ctagsCache name path -> type will not work.
+		vv := v.Field(field)
+		f := t.Field(field)
+		name, skip, omitempty := parseStructField(f)
+		ctagName := 0
+		if !skip {
+			ctagName = enc.name2tag(name)
+		}
+		fi := mkFieldInfo(vv, ctagName, f)
+		fi.isPrivate = len(f.PkgPath) != 0 || skip
+		fi.isOmitEmpty = omitempty
+		if !fi.isPrivate {
+			err := enc.encodeValue(v.Field(field), rdser, fi, nil)
 			if err != nil {
 				return err
 			}
@@ -242,33 +280,6 @@ var hexCharToUint = [256]uint64{
 	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 }
 
-const invalidUuidPair = uint16(0xffff)
-
-var uuidHexPairToByte = func() [1 << 16]uint16 {
-	var table [1 << 16]uint16
-	for i := range table {
-		table[i] = invalidUuidPair
-	}
-	for hi := range 256 {
-		hiVal := hexCharToUint[hi]
-		if hiVal > 15 {
-			continue
-		}
-		for lo := range 256 {
-			loVal := hexCharToUint[lo]
-			if loVal > 15 {
-				continue
-			}
-			table[uint16(hi)<<8|uint16(lo)] = uint16(hiVal<<4 | loVal)
-		}
-	}
-	return table
-}()
-
-func uuidHexPair(str string, pos int) uint16 {
-	return uuidHexPairToByte[uint16(str[pos])<<8|uint16(str[pos+1])]
-}
-
 func generateError(ch byte, str string) (res [2]uint64, err error) {
 	if ch == '-' {
 		err = fmt.Errorf("Invalid UUID format: '%s'", str)
@@ -276,50 +287,6 @@ func generateError(ch byte, str string) (res [2]uint64, err error) {
 		err = fmt.Errorf("UUID cannot contain char '%c': '%s'", ch, str)
 	}
 	return
-}
-
-func ParseUuid(str string) (res [2]uint64, err error) {
-	if res, ok := parseUuidFast(str); ok {
-		return res, nil
-	}
-	return parseUuidSlow(str)
-}
-
-func parseUuidFast(str string) (res [2]uint64, ok bool) {
-	var p0, p1, p2, p3, p4, p5, p6, p7 uint16
-	var p8, p9, p10, p11, p12, p13, p14, p15 uint16
-
-	switch len(str) {
-	case 0:
-		return res, true
-	case 32:
-		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
-		p4, p5, p6, p7 = uuidHexPair(str, 8), uuidHexPair(str, 10), uuidHexPair(str, 12), uuidHexPair(str, 14)
-		p8, p9, p10, p11 = uuidHexPair(str, 16), uuidHexPair(str, 18), uuidHexPair(str, 20), uuidHexPair(str, 22)
-		p12, p13, p14, p15 = uuidHexPair(str, 24), uuidHexPair(str, 26), uuidHexPair(str, 28), uuidHexPair(str, 30)
-	case 36:
-		if str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-' {
-			return res, false
-		}
-		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
-		p4, p5, p6, p7 = uuidHexPair(str, 9), uuidHexPair(str, 11), uuidHexPair(str, 14), uuidHexPair(str, 16)
-		p8, p9, p10, p11 = uuidHexPair(str, 19), uuidHexPair(str, 21), uuidHexPair(str, 24), uuidHexPair(str, 26)
-		p12, p13, p14, p15 = uuidHexPair(str, 28), uuidHexPair(str, 30), uuidHexPair(str, 32), uuidHexPair(str, 34)
-	default:
-		return res, false
-	}
-
-	if p0|p1|p2|p3|p4|p5|p6|p7|p8|p9|p10|p11|p12|p13|p14|p15 > 0xff {
-		return res, false
-	}
-	res[0] = uint64(p0)<<56 | uint64(p1)<<48 | uint64(p2)<<40 | uint64(p3)<<32 |
-		uint64(p4)<<24 | uint64(p5)<<16 | uint64(p6)<<8 | uint64(p7)
-	res[1] = uint64(p8)<<56 | uint64(p9)<<48 | uint64(p10)<<40 | uint64(p11)<<32 |
-		uint64(p12)<<24 | uint64(p13)<<16 | uint64(p14)<<8 | uint64(p15)
-	if (res[0] != 0 || res[1] != 0) && (res[1]>>63) == 0 {
-		return res, false
-	}
-	return res, true
 }
 
 func parseUuidSlow(str string) (res [2]uint64, err error) {

--- a/cjson/encoder.go
+++ b/cjson/encoder.go
@@ -124,27 +124,25 @@ func parseStructField(sf reflect.StructField) (name string, skip, omitEmpty bool
 	return
 }
 
-func (enc *Encoder) encodeStruct(v reflect.Value, rdser *Serializer, idx []int) error {
+func (enc *Encoder) encodeStruct(v reflect.Value, rdser *Serializer, cache *ctagsWCache) error {
+	t := v.Type()
 	for field := 0; field < v.NumField(); field++ {
-
-		iidx := idx
 		var ce *ctagsWCacheEntry
-		if iidx == nil {
-			// if idx is null - we have top level interface field,
+		if cache == nil {
+			// if cache is null - we have top level interface field,
 			// in this case we can have any untyped data in deep, so
 			// ctagsCache 'name path' -> type will not work
 			// So here is using slow path: use reflect to obtain info about each field
 			ce = &ctagsWCacheEntry{}
 		} else {
 			// We have not interface fields on top level, so using cache
-			iidx = append(idx, field)
-			ce = enc.state.ctagsWCache.Lookup(iidx)
+			ce = cache.LookupField(field)
 		}
 
 		if ce.ctagName == 0 && !ce.isPrivate {
 			// No data in cache: use reflect to get data about field
 			vv := v.Field(field)
-			f := v.Type().Field(field)
+			f := t.Field(field)
 			name, skip, omitempty := parseStructField(f)
 			ctagName := 0
 			if !skip {
@@ -161,8 +159,12 @@ func (enc *Encoder) encodeStruct(v reflect.Value, rdser *Serializer, idx []int) 
 		}
 
 		if !ce.isPrivate {
+			var subCache *ctagsWCache
+			if cache != nil {
+				subCache = &ce.subCache
+			}
 			// process field, except private unexported fields
-			err := enc.encodeValue(v.Field(field), rdser, ce.fieldInfo, iidx)
+			err := enc.encodeValue(v.Field(field), rdser, ce.fieldInfo, subCache)
 			if err != nil {
 				return err
 			}
@@ -188,7 +190,7 @@ func (enc *Encoder) name2tag(name string) int {
 	return tagName
 }
 
-func (enc *Encoder) encodeMap(v reflect.Value, rdser *Serializer, idx []int) error {
+func (enc *Encoder) encodeMap(v reflect.Value, rdser *Serializer, cache *ctagsWCache) error {
 	keys := v.MapKeys()
 
 	f := fieldInfo{}
@@ -213,7 +215,7 @@ func (enc *Encoder) encodeMap(v reflect.Value, rdser *Serializer, idx []int) err
 		}
 
 		f.ctagName = enc.name2tag(keyName)
-		err := enc.encodeValue(vv, rdser, f, idx)
+		err := enc.encodeValue(vv, rdser, f, cache)
 		if err != nil {
 			return err
 		}
@@ -240,6 +242,33 @@ var hexCharToUint = [256]uint64{
 	255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
 }
 
+const invalidUuidPair = uint16(0xffff)
+
+var uuidHexPairToByte = func() [1 << 16]uint16 {
+	var table [1 << 16]uint16
+	for i := range table {
+		table[i] = invalidUuidPair
+	}
+	for hi := range 256 {
+		hiVal := hexCharToUint[hi]
+		if hiVal > 15 {
+			continue
+		}
+		for lo := range 256 {
+			loVal := hexCharToUint[lo]
+			if loVal > 15 {
+				continue
+			}
+			table[uint16(hi)<<8|uint16(lo)] = uint16(hiVal<<4 | loVal)
+		}
+	}
+	return table
+}()
+
+func uuidHexPair(str string, pos int) uint16 {
+	return uuidHexPairToByte[uint16(str[pos])<<8|uint16(str[pos+1])]
+}
+
 func generateError(ch byte, str string) (res [2]uint64, err error) {
 	if ch == '-' {
 		err = fmt.Errorf("Invalid UUID format: '%s'", str)
@@ -250,6 +279,50 @@ func generateError(ch byte, str string) (res [2]uint64, err error) {
 }
 
 func ParseUuid(str string) (res [2]uint64, err error) {
+	if res, ok := parseUuidFast(str); ok {
+		return res, nil
+	}
+	return parseUuidSlow(str)
+}
+
+func parseUuidFast(str string) (res [2]uint64, ok bool) {
+	var p0, p1, p2, p3, p4, p5, p6, p7 uint16
+	var p8, p9, p10, p11, p12, p13, p14, p15 uint16
+
+	switch len(str) {
+	case 0:
+		return res, true
+	case 32:
+		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
+		p4, p5, p6, p7 = uuidHexPair(str, 8), uuidHexPair(str, 10), uuidHexPair(str, 12), uuidHexPair(str, 14)
+		p8, p9, p10, p11 = uuidHexPair(str, 16), uuidHexPair(str, 18), uuidHexPair(str, 20), uuidHexPair(str, 22)
+		p12, p13, p14, p15 = uuidHexPair(str, 24), uuidHexPair(str, 26), uuidHexPair(str, 28), uuidHexPair(str, 30)
+	case 36:
+		if str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-' {
+			return res, false
+		}
+		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
+		p4, p5, p6, p7 = uuidHexPair(str, 9), uuidHexPair(str, 11), uuidHexPair(str, 14), uuidHexPair(str, 16)
+		p8, p9, p10, p11 = uuidHexPair(str, 19), uuidHexPair(str, 21), uuidHexPair(str, 24), uuidHexPair(str, 26)
+		p12, p13, p14, p15 = uuidHexPair(str, 28), uuidHexPair(str, 30), uuidHexPair(str, 32), uuidHexPair(str, 34)
+	default:
+		return res, false
+	}
+
+	if p0|p1|p2|p3|p4|p5|p6|p7|p8|p9|p10|p11|p12|p13|p14|p15 > 0xff {
+		return res, false
+	}
+	res[0] = uint64(p0)<<56 | uint64(p1)<<48 | uint64(p2)<<40 | uint64(p3)<<32 |
+		uint64(p4)<<24 | uint64(p5)<<16 | uint64(p6)<<8 | uint64(p7)
+	res[1] = uint64(p8)<<56 | uint64(p9)<<48 | uint64(p10)<<40 | uint64(p11)<<32 |
+		uint64(p12)<<24 | uint64(p13)<<16 | uint64(p14)<<8 | uint64(p15)
+	if (res[0] != 0 || res[1] != 0) && (res[1]>>63) == 0 {
+		return res, false
+	}
+	return res, true
+}
+
+func parseUuidSlow(str string) (res [2]uint64, err error) {
 	switch len(str) {
 	case 0:
 		return
@@ -591,7 +664,7 @@ func ParseUuid(str string) (res [2]uint64, err error) {
 	return
 }
 
-func (enc *Encoder) encodeSlice(v reflect.Value, rdser *Serializer, f fieldInfo, idx []int) error {
+func (enc *Encoder) encodeSlice(v reflect.Value, rdser *Serializer, f fieldInfo, cache *ctagsWCache) error {
 	l := v.Len()
 	if l == 0 && f.isOmitEmpty {
 		return nil
@@ -712,7 +785,7 @@ func (enc *Encoder) encodeSlice(v reflect.Value, rdser *Serializer, f fieldInfo,
 						f = mkFieldInfo(vv, 0, reflect.StructField{})
 						f.isOmitEmpty = false
 					}
-					err := enc.encodeValue(vv, rdser, f, idx)
+					err := enc.encodeValue(vv, rdser, f, cache)
 					if err != nil {
 						return err
 					}
@@ -768,7 +841,7 @@ func (enc *Encoder) encodeSlice(v reflect.Value, rdser *Serializer, f fieldInfo,
 						f = mkFieldInfo(vv, 0, reflect.StructField{})
 						f.isOmitEmpty = false
 					}
-					err := enc.encodeValue(vv, rdser, f, idx)
+					err := enc.encodeValue(vv, rdser, f, cache)
 					if err != nil {
 						return err
 					}
@@ -779,7 +852,7 @@ func (enc *Encoder) encodeSlice(v reflect.Value, rdser *Serializer, f fieldInfo,
 	return nil
 }
 
-func (enc *Encoder) encodeValue(v reflect.Value, rdser *Serializer, f fieldInfo, idx []int) error {
+func (enc *Encoder) encodeValue(v reflect.Value, rdser *Serializer, f fieldInfo, cache *ctagsWCache) error {
 
 	if f.isNullable && v.IsNil() {
 		if !f.isOmitEmpty {
@@ -842,7 +915,7 @@ func (enc *Encoder) encodeValue(v reflect.Value, rdser *Serializer, f fieldInfo,
 			rdser.PutVString(val)
 		}
 	case reflect.Slice, reflect.Array:
-		err := enc.encodeSlice(v, rdser, f, idx)
+		err := enc.encodeSlice(v, rdser, f, cache)
 		if err != nil {
 			return err
 		}
@@ -856,20 +929,20 @@ func (enc *Encoder) encodeValue(v reflect.Value, rdser *Serializer, f fieldInfo,
 		}
 		if !f.isAnon {
 			rdser.PutCTag(mkctag(TAG_OBJECT, f.ctagName, 0))
-			err := enc.encodeStruct(v, rdser, idx)
+			err := enc.encodeStruct(v, rdser, cache)
 			if err != nil {
 				return err
 			}
 			rdser.PutCTag(mkctag(TAG_END, 0, 0))
 		} else {
-			err := enc.encodeStruct(v, rdser, idx)
+			err := enc.encodeStruct(v, rdser, cache)
 			if err != nil {
 				return err
 			}
 		}
 	case reflect.Map:
 		rdser.PutCTag(mkctag(TAG_OBJECT, f.ctagName, 0))
-		err := enc.encodeMap(v, rdser, idx)
+		err := enc.encodeMap(v, rdser, cache)
 		if err != nil {
 			return err
 		}
@@ -896,20 +969,20 @@ func (enc *Encoder) Encode(src any, wrser *Serializer) (stateToken int, err erro
 	defer enc.state.lock.Unlock()
 
 	pos := len(wrser.Bytes())
-	wrser.PutVarUInt(TAG_END)
-	wrser.PutUInt32(0)
 	enc.tagsMatcher = &enc.state.tagsMatcher
 	enc.tmUpdated = false
-	err = enc.encodeValue(v, wrser, mkFieldInfo(v, 0, reflect.StructField{}), make([]int, 0, 10))
+	err = enc.encodeValue(v, wrser, mkFieldInfo(v, 0, reflect.StructField{}), &enc.state.ctagsWCache)
 	if err != nil {
 		return
 	}
 
 	if enc.tmUpdated {
+		payloadLen := len(wrser.buf) - pos
+		wrser.grow(int(unsafe.Sizeof(uint32(0))) + 1)
+		copy(wrser.buf[pos+int(unsafe.Sizeof(uint32(0)))+1:], wrser.buf[pos:pos+payloadLen])
+		wrser.buf[pos] = TAG_END
 		*(*uint32)(unsafe.Pointer(&wrser.Bytes()[pos+1])) = uint32(len(wrser.buf) - pos)
 		enc.tagsMatcher.WriteUpdated(wrser)
-	} else {
-		wrser.TruncateStart(int(unsafe.Sizeof(uint32(0))) + 1)
 	}
 	stateToken = int(enc.state.StateToken)
 	return
@@ -923,7 +996,7 @@ func (enc *Encoder) EncodeRaw(src any, wrser *Serializer) error {
 	enc.tmUpdated = false
 
 	enc.tagsMatcher = &enc.state.tagsMatcher
-	err := enc.encodeValue(v, wrser, mkFieldInfo(v, 0, reflect.StructField{}), make([]int, 0, 10))
+	err := enc.encodeValue(v, wrser, mkFieldInfo(v, 0, reflect.StructField{}), &enc.state.ctagsWCache)
 	if err != nil {
 		return err
 	}

--- a/cjson/encoder_bench_test.go
+++ b/cjson/encoder_bench_test.go
@@ -220,6 +220,7 @@ func TestParseUuidMatchesSlowPath(t *testing.T) {
 		"",
 		"550e8400-e29b-41d4-a716-446655440000",
 		"550e8400e29b41d4a716446655440000",
+		"ffffffff-ffff-ffff-ffff-ffffffffffff",
 		"00000000-0000-0000-0000-000000000000",
 		"550e8400-e29b-41d4-2716-446655440000",
 		"550e8400-e29b-41d4-a716-44665544000x",

--- a/cjson/encoder_bench_test.go
+++ b/cjson/encoder_bench_test.go
@@ -1,0 +1,248 @@
+package cjson
+
+import (
+	"bytes"
+	"encoding/gob"
+	"reflect"
+	"testing"
+)
+
+type benchEncoderNestedDoc struct {
+	Code   int    `json:"code"`
+	Label  string `json:"label"`
+	Active bool   `json:"active"`
+}
+
+type benchEncoderTypicalDoc struct {
+	ID        int                   `json:"id"`
+	UUID      string                `json:"uuid" reindex:"uuid,,uuid"`
+	Name      string                `json:"name"`
+	Category  string                `json:"category"`
+	Count     int64                 `json:"count"`
+	Score     float64               `json:"score"`
+	Enabled   bool                  `json:"enabled"`
+	Tags      []string              `json:"tags"`
+	Values    []int                 `json:"values"`
+	Vector    []float32             `json:"vector"`
+	Nested    benchEncoderNestedDoc `json:"nested"`
+	Optional  string                `json:"optional,omitempty"`
+	SkipEmpty []int                 `json:"skip_empty,omitempty"`
+}
+
+type benchEncoderStringDoc struct {
+	ID     int      `json:"id"`
+	Title  string   `json:"title"`
+	Body   string   `json:"body"`
+	Tags   []string `json:"tags"`
+	Status string   `json:"status"`
+}
+
+type benchEncoderSliceDoc struct {
+	ID     int       `json:"id"`
+	Values []int     `json:"values"`
+	Vector []float32 `json:"vector"`
+}
+
+func newBenchEncoderTypicalDoc() benchEncoderTypicalDoc {
+	vector := make([]float32, 64)
+	for i := range vector {
+		vector[i] = float32(i) / 10
+	}
+	return benchEncoderTypicalDoc{
+		ID:       42,
+		UUID:     "550e8400-e29b-41d4-a716-446655440000",
+		Name:     "cjson encoder benchmark document",
+		Category: "perf",
+		Count:    123456789,
+		Score:    42.75,
+		Enabled:  true,
+		Tags:     []string{"go", "cjson", "encoder", "hot-path"},
+		Values:   []int{1, 8, 64, 512, 4096, 8192, -42, -8192},
+		Vector:   vector,
+		Nested: benchEncoderNestedDoc{
+			Code:   7,
+			Label:  "nested payload",
+			Active: true,
+		},
+	}
+}
+
+func benchmarkCJSONEncodeRaw(b *testing.B, doc any) {
+	state := NewState()
+	enc := state.NewEncoder()
+	ser := NewPoolSerializer()
+	if err := enc.EncodeRaw(doc, ser); err != nil {
+		b.Fatalf("warm cjson encoder: %v", err)
+	}
+	ser.Close()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		ser := NewPoolSerializer()
+		if err := enc.EncodeRaw(doc, ser); err != nil {
+			b.Fatalf("encode cjson: %v", err)
+		}
+		benchBytesSink = ser.Bytes()
+		ser.Close()
+	}
+}
+
+func BenchmarkCJSONEncoderTypicalDocument(b *testing.B) {
+	benchmarkCJSONEncodeRaw(b, newBenchEncoderTypicalDoc())
+}
+
+func BenchmarkGobEncoderTypicalDocument(b *testing.B) {
+	doc := newBenchEncoderTypicalDoc()
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(doc); err != nil {
+		b.Fatalf("warm gob encoder: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		buf.Reset()
+		if err := enc.Encode(doc); err != nil {
+			b.Fatalf("encode gob: %v", err)
+		}
+		benchBytesSink = buf.Bytes()
+	}
+}
+
+func BenchmarkCJSONEncoderFocused(b *testing.B) {
+	b.Run("nested", func(b *testing.B) {
+		benchmarkCJSONEncodeRaw(b, benchEncoderNestedDoc{Code: 42, Label: "nested", Active: true})
+	})
+	b.Run("uuid", func(b *testing.B) {
+		benchmarkCJSONEncodeRaw(b, struct {
+			UUID string `json:"uuid" reindex:"uuid,,uuid"`
+		}{UUID: "550e8400-e29b-41d4-a716-446655440000"})
+	})
+	b.Run("string-heavy", func(b *testing.B) {
+		benchmarkCJSONEncodeRaw(b, benchEncoderStringDoc{
+			ID:     1,
+			Title:  "The Art of Query Planning",
+			Body:   "abcdefghijklmnopqrstuvwxyz-0123456789-cjson-encoder",
+			Tags:   []string{"alpha", "beta", "gamma", "delta", "epsilon"},
+			Status: "published",
+		})
+	})
+	b.Run("slice-heavy", func(b *testing.B) {
+		vector := make([]float32, 256)
+		for i := range vector {
+			vector[i] = float32(i) / 100
+		}
+		benchmarkCJSONEncodeRaw(b, benchEncoderSliceDoc{
+			ID:     1,
+			Values: []int{1, 8, 64, 512, 4096, 8192, -42, -8192, 16384, -16384},
+			Vector: vector,
+		})
+	})
+}
+
+func BenchmarkCJSONEncoderArgumentShape(b *testing.B) {
+	state := NewState()
+	enc := state.NewEncoder()
+	doc := benchSliceDocF32{ID: 1, Values: make([]float32, 256)}
+	for i := range doc.Values {
+		doc.Values[i] = float32(i) / 10
+	}
+	preboxed := any(doc)
+
+	ser := NewPoolSerializer()
+	if err := enc.EncodeRaw(preboxed, ser); err != nil {
+		b.Fatalf("warm cjson encoder: %v", err)
+	}
+	ser.Close()
+
+	b.Run("value-direct", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := NewPoolSerializer()
+			if err := enc.EncodeRaw(doc, ser); err != nil {
+				b.Fatalf("encode cjson value: %v", err)
+			}
+			benchBytesSink = ser.Bytes()
+			ser.Close()
+		}
+	})
+
+	b.Run("value-preboxed", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := NewPoolSerializer()
+			if err := enc.EncodeRaw(preboxed, ser); err != nil {
+				b.Fatalf("encode cjson preboxed value: %v", err)
+			}
+			benchBytesSink = ser.Bytes()
+			ser.Close()
+		}
+	})
+
+	b.Run("pointer", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := NewPoolSerializer()
+			if err := enc.EncodeRaw(&doc, ser); err != nil {
+				b.Fatalf("encode cjson pointer: %v", err)
+			}
+			benchBytesSink = ser.Bytes()
+			ser.Close()
+		}
+	})
+}
+
+func BenchmarkParseUuid(b *testing.B) {
+	for _, uuid := range []string{
+		"550e8400-e29b-41d4-a716-446655440000",
+		"550e8400e29b41d4a716446655440000",
+		"00000000-0000-0000-0000-000000000000",
+	} {
+		b.Run(uuid, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				parsed, err := ParseUuid(uuid)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchUint64Sink ^= parsed[0] ^ parsed[1]
+			}
+		})
+	}
+}
+
+func TestCJSONEncoderTypicalDocumentStableWire(t *testing.T) {
+	state := NewState()
+	enc := state.NewEncoder()
+	doc := newBenchEncoderTypicalDoc()
+
+	ser1 := NewPoolSerializer()
+	if err := enc.EncodeRaw(doc, ser1); err != nil {
+		t.Fatalf("first encode: %v", err)
+	}
+	wire1 := append([]byte(nil), ser1.Bytes()...)
+	ser1.Close()
+
+	ser2 := NewPoolSerializer()
+	if err := enc.EncodeRaw(doc, ser2); err != nil {
+		t.Fatalf("second encode: %v", err)
+	}
+	wire2 := append([]byte(nil), ser2.Bytes()...)
+	ser2.Close()
+
+	if !bytes.Equal(wire1, wire2) {
+		t.Fatalf("EncodeRaw produced unstable wire bytes: len1=%d len2=%d", len(wire1), len(wire2))
+	}
+
+	dec := state.NewDecoder(benchEncoderTypicalDoc{}, nil)
+	defer dec.Finalize()
+	var decoded benchEncoderTypicalDoc
+	if err := dec.Decode(wire2, &decoded); err != nil {
+		t.Fatalf("decode encoded document: %v", err)
+	}
+	if !reflect.DeepEqual(doc, decoded) {
+		t.Fatalf("EncodeRaw/Decode mismatch:\nwant: %#v\n got: %#v", doc, decoded)
+	}
+}

--- a/cjson/encoder_bench_test.go
+++ b/cjson/encoder_bench_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/gob"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type benchEncoderNestedDoc struct {
@@ -208,6 +210,30 @@ func BenchmarkParseUuid(b *testing.B) {
 					b.Fatal(err)
 				}
 				benchUint64Sink ^= parsed[0] ^ parsed[1]
+			}
+		})
+	}
+}
+
+func TestParseUuidMatchesSlowPath(t *testing.T) {
+	for _, uuid := range []string{
+		"",
+		"550e8400-e29b-41d4-a716-446655440000",
+		"550e8400e29b41d4a716446655440000",
+		"00000000-0000-0000-0000-000000000000",
+		"550e8400-e29b-41d4-2716-446655440000",
+		"550e8400-e29b-41d4-a716-44665544000x",
+		"550e8400-e29b41d4-a716-446655440000",
+		"550e8400-e29b-41d4-a716-44665544000",
+	} {
+		t.Run(uuid, func(t *testing.T) {
+			got, gotErr := ParseUuid(uuid)
+			want, wantErr := parseUuidSlow(uuid)
+			assert.Equal(t, want, got)
+			if wantErr == nil {
+				assert.NoError(t, gotErr)
+			} else if assert.Error(t, gotErr) {
+				assert.Equal(t, wantErr.Error(), gotErr.Error())
 			}
 		})
 	}

--- a/cjson/encoder_decoder_slice_bench_test.go
+++ b/cjson/encoder_decoder_slice_bench_test.go
@@ -1,6 +1,9 @@
 package cjson
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 type benchSliceDocF32 struct {
 	ID     int       `json:"id"`
@@ -10,6 +13,11 @@ type benchSliceDocF32 struct {
 type benchSliceDocF64 struct {
 	ID     int       `json:"id"`
 	Values []float64 `json:"values"`
+}
+
+type benchSliceStruct struct {
+	ID   int
+	Name string
 }
 
 func BenchmarkEncoderEncodeSliceFloat32(b *testing.B) {
@@ -205,4 +213,58 @@ func BenchmarkDecoderDecodeSliceFloat64Reuse(b *testing.B) {
 		}
 	}
 	benchUint64Sink = uint64(len(dst.Values))
+}
+
+func BenchmarkDecoderMkSliceExtend(b *testing.B) {
+	const count = 64
+
+	b.Run("int-empty", func(b *testing.B) {
+		var dst []int
+		v := reflect.ValueOf(&dst).Elem()
+		b.ReportAllocs()
+		for b.Loop() {
+			dst = nil
+			benchUint64Sink += uint64(mkSlice(&v, count))
+		}
+	})
+
+	b.Run("int-append-no-cap", func(b *testing.B) {
+		dst := make([]int, 1, 1)
+		v := reflect.ValueOf(&dst).Elem()
+		b.ReportAllocs()
+		for b.Loop() {
+			dst = dst[:1:1]
+			benchUint64Sink += uint64(mkSlice(&v, count))
+		}
+	})
+
+	b.Run("int-append-reuse-cap", func(b *testing.B) {
+		dst := make([]int, 1, count+1)
+		v := reflect.ValueOf(&dst).Elem()
+		b.ReportAllocs()
+		for b.Loop() {
+			dst = dst[:1]
+			benchUint64Sink += uint64(mkSlice(&v, count))
+		}
+	})
+
+	b.Run("struct-append-no-cap", func(b *testing.B) {
+		dst := make([]benchSliceStruct, 1, 1)
+		v := reflect.ValueOf(&dst).Elem()
+		b.ReportAllocs()
+		for b.Loop() {
+			dst = dst[:1:1]
+			benchUint64Sink += uint64(mkSlice(&v, count))
+		}
+	})
+
+	b.Run("struct-append-reuse-cap", func(b *testing.B) {
+		dst := make([]benchSliceStruct, 1, count+1)
+		v := reflect.ValueOf(&dst).Elem()
+		b.ReportAllocs()
+		for b.Loop() {
+			dst = dst[:1]
+			benchUint64Sink += uint64(mkSlice(&v, count))
+		}
+	})
 }

--- a/cjson/parse_uuid_fast_amd64.go
+++ b/cjson/parse_uuid_fast_amd64.go
@@ -1,0 +1,19 @@
+//go:build amd64 && !purego
+
+package cjson
+
+func ParseUuid(str string) (res [2]uint64, err error) {
+	switch len(str) {
+	case 0:
+		return res, nil
+	case 32, 36:
+		hi, lo, ok := parseUuidFastAsm(str)
+		if ok {
+			return [2]uint64{hi, lo}, nil
+		}
+	}
+	return parseUuidSlow(str)
+}
+
+//go:noescape
+func parseUuidFastAsm(str string) (hi uint64, lo uint64, ok bool)

--- a/cjson/parse_uuid_fast_amd64.s
+++ b/cjson/parse_uuid_fast_amd64.s
@@ -1,0 +1,134 @@
+//go:build amd64 && !purego
+
+#include "textflag.h"
+
+#define DECODE16(in, out) \
+	MOVO in, X10; \
+	MOVO in, X11; \
+	PSRLW $4, X10; \
+	PAND X5, X10; \
+	PAND X5, X11; \
+	MOVO X6, X12; \
+	PSHUFB X10, X12; \
+	MOVO X11, X13; \
+	PCMPGTB X12, X13; \
+	MOVO X7, X12; \
+	PSHUFB X10, X12; \
+	MOVO X12, X14; \
+	PCMPGTB X11, X14; \
+	PAND X14, X13; \
+	PMOVMSKB X13, AX; \
+	CMPL AX, $0xffff; \
+	JNE fail; \
+	MOVO X8, X12; \
+	PSHUFB X10, X12; \
+	PADDB X12, X11; \
+	MOVO X11, X12; \
+	PSLLW $4, X12; \
+	PSRLW $8, X11; \
+	POR X11, X12; \
+	PSHUFB X9, X12; \
+	MOVQ X12, out; \
+	BSWAPQ out
+
+// func parseUuidFastAsm(str string) (hi uint64, lo uint64, ok bool)
+TEXT ·parseUuidFastAsm(SB), NOSPLIT, $0-40
+	MOVQ str_base+0(FP), SI
+	MOVQ str_len+8(FP), CX
+	MOVOU ·uuidHexLowMask<>(SB), X5
+	MOVOU ·uuidHexMinMinusOne<>(SB), X6
+	MOVOU ·uuidHexMaxPlusOne<>(SB), X7
+	MOVOU ·uuidHexOffset<>(SB), X8
+	MOVOU ·uuidHexPack<>(SB), X9
+
+	CMPQ CX, $32
+	JE compact
+	CMPQ CX, $36
+	JE dashed
+	JMP fail
+
+compact:
+	MOVOU 0(SI), X0
+	DECODE16(X0, R8)
+	MOVOU 16(SI), X0
+	DECODE16(X0, R9)
+	JMP validate
+
+dashed:
+	CMPB 8(SI), $'-'
+	JNE fail
+	CMPB 13(SI), $'-'
+	JNE fail
+	CMPB 18(SI), $'-'
+	JNE fail
+	CMPB 23(SI), $'-'
+	JNE fail
+
+	MOVOU 0(SI), X0
+	MOVOU 16(SI), X1
+	MOVOU ·uuidDashFirstA<>(SB), X2
+	PSHUFB X2, X0
+	MOVOU ·uuidDashFirstB<>(SB), X2
+	PSHUFB X2, X1
+	POR X1, X0
+	DECODE16(X0, R8)
+
+	MOVOU 19(SI), X0
+	MOVOU ·uuidDashSecondA<>(SB), X2
+	PSHUFB X2, X0
+	MOVBLZX 35(SI), AX
+	MOVD AX, X1
+	PSLLDQ $15, X1
+	POR X1, X0
+	DECODE16(X0, R9)
+
+validate:
+	MOVQ R8, AX
+	ORQ R9, AX
+	JZ ok
+	TESTQ R9, R9
+	JGE fail
+
+ok:
+	MOVQ R8, hi+16(FP)
+	MOVQ R9, lo+24(FP)
+	MOVB $1, ok+32(FP)
+	RET
+
+fail:
+	MOVQ $0, hi+16(FP)
+	MOVQ $0, lo+24(FP)
+	MOVB $0, ok+32(FP)
+	RET
+
+DATA ·uuidHexLowMask<>+0(SB)/8, $0x0f0f0f0f0f0f0f0f
+DATA ·uuidHexLowMask<>+8(SB)/8, $0x0f0f0f0f0f0f0f0f
+GLOBL ·uuidHexLowMask<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidHexOffset<>+0(SB)/8, $0x0009000900000000
+DATA ·uuidHexOffset<>+8(SB)/8, $0x0000000000000000
+GLOBL ·uuidHexOffset<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidHexMinMinusOne<>+0(SB)/8, $0x7f007f00ff7f7f7f
+DATA ·uuidHexMinMinusOne<>+8(SB)/8, $0x7f7f7f7f7f7f7f7f
+GLOBL ·uuidHexMinMinusOne<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidHexMaxPlusOne<>+0(SB)/8, $0x000700070a000000
+DATA ·uuidHexMaxPlusOne<>+8(SB)/8, $0x0000000000000000
+GLOBL ·uuidHexMaxPlusOne<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidHexPack<>+0(SB)/8, $0x0e0c0a0806040200
+DATA ·uuidHexPack<>+8(SB)/8, $0x8080808080808080
+GLOBL ·uuidHexPack<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidDashFirstA<>+0(SB)/8, $0x0706050403020100
+DATA ·uuidDashFirstA<>+8(SB)/8, $0x80800f0e0c0b0a09
+GLOBL ·uuidDashFirstA<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidDashFirstB<>+0(SB)/8, $0x8080808080808080
+DATA ·uuidDashFirstB<>+8(SB)/8, $0x0100808080808080
+GLOBL ·uuidDashFirstB<>(SB), RODATA|NOPTR, $16
+
+DATA ·uuidDashSecondA<>+0(SB)/8, $0x0807060503020100
+DATA ·uuidDashSecondA<>+8(SB)/8, $0x800f0e0d0c0b0a09
+GLOBL ·uuidDashSecondA<>(SB), RODATA|NOPTR, $16

--- a/cjson/parse_uuid_fast_fallback.go
+++ b/cjson/parse_uuid_fast_fallback.go
@@ -2,12 +2,20 @@
 
 package cjson
 
-const invalidUuidPair = uint16(0xffff)
+func ParseUuid(str string) (res [2]uint64, err error) {
+	if res, ok := parseUuidFastGo(str); ok {
+		return res, nil
+	}
+	return parseUuidSlow(str)
+}
 
-var uuidHexPairToByte = func() [1 << 16]uint16 {
-	var table [1 << 16]uint16
+// 0xff is also a valid decoded byte, so UUIDs containing ff fall through to parseUuidSlow.
+const invalidUuidByte = byte(0xff)
+
+var uuidHexPairToByte = func() [1 << 16]byte {
+	var table [1 << 16]byte
 	for i := range table {
-		table[i] = invalidUuidPair
+		table[i] = invalidUuidByte
 	}
 	for hi := range 256 {
 		hiVal := hexCharToUint[hi]
@@ -19,26 +27,24 @@ var uuidHexPairToByte = func() [1 << 16]uint16 {
 			if loVal > 15 {
 				continue
 			}
-			table[uint16(hi)<<8|uint16(lo)] = uint16(hiVal<<4 | loVal)
+			table[hi<<8|lo] = byte(hiVal<<4 | loVal)
 		}
 	}
 	return table
 }()
 
-func ParseUuid(str string) (res [2]uint64, err error) {
-	if res, ok := parseUuidFastGo(str); ok {
-		return res, nil
-	}
-	return parseUuidSlow(str)
+func hasFFByte(v uint64) bool {
+	v = ^v
+	return ((v - 0x0101010101010101) &^ v & 0x8080808080808080) != 0
 }
 
-func uuidHexPair(str string, pos int) uint16 {
+func uuidHexPair(str string, pos int) byte {
 	return uuidHexPairToByte[uint16(str[pos])<<8|uint16(str[pos+1])]
 }
 
 func parseUuidFastGo(str string) (res [2]uint64, ok bool) {
-	var p0, p1, p2, p3, p4, p5, p6, p7 uint16
-	var p8, p9, p10, p11, p12, p13, p14, p15 uint16
+	var p0, p1, p2, p3, p4, p5, p6, p7 byte
+	var p8, p9, p10, p11, p12, p13, p14, p15 byte
 
 	switch len(str) {
 	case 0:
@@ -60,13 +66,13 @@ func parseUuidFastGo(str string) (res [2]uint64, ok bool) {
 		return res, false
 	}
 
-	if p0|p1|p2|p3|p4|p5|p6|p7|p8|p9|p10|p11|p12|p13|p14|p15 > 0xff {
-		return res, false
-	}
 	res[0] = uint64(p0)<<56 | uint64(p1)<<48 | uint64(p2)<<40 | uint64(p3)<<32 |
 		uint64(p4)<<24 | uint64(p5)<<16 | uint64(p6)<<8 | uint64(p7)
 	res[1] = uint64(p8)<<56 | uint64(p9)<<48 | uint64(p10)<<40 | uint64(p11)<<32 |
 		uint64(p12)<<24 | uint64(p13)<<16 | uint64(p14)<<8 | uint64(p15)
+	if hasFFByte(res[0]) || hasFFByte(res[1]) {
+		return res, false
+	}
 	if (res[0] != 0 || res[1] != 0) && (res[1]>>63) == 0 {
 		return res, false
 	}

--- a/cjson/parse_uuid_fast_fallback.go
+++ b/cjson/parse_uuid_fast_fallback.go
@@ -1,0 +1,74 @@
+//go:build !amd64 || purego
+
+package cjson
+
+const invalidUuidPair = uint16(0xffff)
+
+var uuidHexPairToByte = func() [1 << 16]uint16 {
+	var table [1 << 16]uint16
+	for i := range table {
+		table[i] = invalidUuidPair
+	}
+	for hi := range 256 {
+		hiVal := hexCharToUint[hi]
+		if hiVal > 15 {
+			continue
+		}
+		for lo := range 256 {
+			loVal := hexCharToUint[lo]
+			if loVal > 15 {
+				continue
+			}
+			table[uint16(hi)<<8|uint16(lo)] = uint16(hiVal<<4 | loVal)
+		}
+	}
+	return table
+}()
+
+func ParseUuid(str string) (res [2]uint64, err error) {
+	if res, ok := parseUuidFastGo(str); ok {
+		return res, nil
+	}
+	return parseUuidSlow(str)
+}
+
+func uuidHexPair(str string, pos int) uint16 {
+	return uuidHexPairToByte[uint16(str[pos])<<8|uint16(str[pos+1])]
+}
+
+func parseUuidFastGo(str string) (res [2]uint64, ok bool) {
+	var p0, p1, p2, p3, p4, p5, p6, p7 uint16
+	var p8, p9, p10, p11, p12, p13, p14, p15 uint16
+
+	switch len(str) {
+	case 0:
+		return res, true
+	case 32:
+		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
+		p4, p5, p6, p7 = uuidHexPair(str, 8), uuidHexPair(str, 10), uuidHexPair(str, 12), uuidHexPair(str, 14)
+		p8, p9, p10, p11 = uuidHexPair(str, 16), uuidHexPair(str, 18), uuidHexPair(str, 20), uuidHexPair(str, 22)
+		p12, p13, p14, p15 = uuidHexPair(str, 24), uuidHexPair(str, 26), uuidHexPair(str, 28), uuidHexPair(str, 30)
+	case 36:
+		if str[8] != '-' || str[13] != '-' || str[18] != '-' || str[23] != '-' {
+			return res, false
+		}
+		p0, p1, p2, p3 = uuidHexPair(str, 0), uuidHexPair(str, 2), uuidHexPair(str, 4), uuidHexPair(str, 6)
+		p4, p5, p6, p7 = uuidHexPair(str, 9), uuidHexPair(str, 11), uuidHexPair(str, 14), uuidHexPair(str, 16)
+		p8, p9, p10, p11 = uuidHexPair(str, 19), uuidHexPair(str, 21), uuidHexPair(str, 24), uuidHexPair(str, 26)
+		p12, p13, p14, p15 = uuidHexPair(str, 28), uuidHexPair(str, 30), uuidHexPair(str, 32), uuidHexPair(str, 34)
+	default:
+		return res, false
+	}
+
+	if p0|p1|p2|p3|p4|p5|p6|p7|p8|p9|p10|p11|p12|p13|p14|p15 > 0xff {
+		return res, false
+	}
+	res[0] = uint64(p0)<<56 | uint64(p1)<<48 | uint64(p2)<<40 | uint64(p3)<<32 |
+		uint64(p4)<<24 | uint64(p5)<<16 | uint64(p6)<<8 | uint64(p7)
+	res[1] = uint64(p8)<<56 | uint64(p9)<<48 | uint64(p10)<<40 | uint64(p11)<<32 |
+		uint64(p12)<<24 | uint64(p13)<<16 | uint64(p14)<<8 | uint64(p15)
+	if (res[0] != 0 || res[1] != 0) && (res[1]>>63) == 0 {
+		return res, false
+	}
+	return res, true
+}

--- a/cjson/serializer.go
+++ b/cjson/serializer.go
@@ -124,7 +124,9 @@ func (s *Serializer) PutFloat32(v float32) *Serializer {
 }
 
 func (s *Serializer) PutDouble(v float64) *Serializer {
-	s.writeIntBits(int64(math.Float64bits(v)), unsafe.Sizeof(v))
+	l := len(s.buf)
+	s.grow(8)
+	binary.LittleEndian.PutUint64(s.buf[l:], math.Float64bits(v))
 	return s
 }
 
@@ -317,6 +319,21 @@ func (s *Serializer) PutVarUInt(v uint64) *Serializer {
 		s.buf[l] = byte(v)
 		return s
 	}
+	if v < 0x4000 {
+		l := len(s.buf)
+		s.grow(2)
+		s.buf[l] = byte(v) | 0x80
+		s.buf[l+1] = byte(v >> 7)
+		return s
+	}
+	if v < 0x200000 {
+		l := len(s.buf)
+		s.grow(3)
+		s.buf[l] = byte(v) | 0x80
+		s.buf[l+1] = byte(v>>7) | 0x80
+		s.buf[l+2] = byte(v >> 14)
+		return s
+	}
 	l := len(s.buf)
 	s.grow(10)
 	rl := binary.PutUvarint(s.buf[l:], v)
@@ -372,11 +389,23 @@ func (s *Serializer) GetUInt64() (v uint64) {
 }
 
 func (s *Serializer) GetDouble() (v float64) {
-	return math.Float64frombits(uint64(s.readIntBits(unsafe.Sizeof(v))))
+	pos := s.pos
+	if pos+8 > len(s.buf) {
+		s.readSizePanic(8)
+	}
+	v = math.Float64frombits(binary.LittleEndian.Uint64(s.buf[pos:]))
+	s.pos = pos + 8
+	return v
 }
 
 func (s *Serializer) GetFloat32() (v float32) {
-	return math.Float32frombits(uint32(s.readIntBits(unsafe.Sizeof(v))))
+	pos := s.pos
+	if pos+4 > len(s.buf) {
+		s.readSizePanic(4)
+	}
+	v = math.Float32frombits(binary.LittleEndian.Uint32(s.buf[pos:]))
+	s.pos = pos + 4
+	return v
 }
 
 func (s *Serializer) GetBytes() (v []byte) {
@@ -406,6 +435,11 @@ func (s *Serializer) SkipVString() {
 		panic(fmt.Errorf("Internal error: serializer need %d bytes, but only %d available", l, len(s.buf)-s.pos))
 	}
 	s.pos += l
+}
+
+//go:noinline
+func (s *Serializer) readSizePanic(sz int) {
+	panic(fmt.Errorf("Internal error: serializer need %d bytes, but only %d available", s.pos+sz, len(s.buf)-s.pos))
 }
 
 func (s *Serializer) readIntBits(sz uintptr) (v int64) {
@@ -482,6 +516,29 @@ func (s *Serializer) GetVarInt() int64 {
 			return int64(uv>>1) ^ -int64(uv&1)
 		}
 	}
+	pos := s.pos
+	if pos+1 < len(s.buf) {
+		b0 := s.buf[pos]
+		b1 := s.buf[pos+1]
+		if b1 < 0x80 {
+			s.pos = pos + 2
+			uv := uint64(b0&0x7f) | uint64(b1)<<7
+			return int64(uv>>1) ^ -int64(uv&1)
+		}
+		if pos+2 < len(s.buf) {
+			b2 := s.buf[pos+2]
+			if b2 < 0x80 {
+				s.pos = pos + 3
+				uv := uint64(b0&0x7f) | uint64(b1&0x7f)<<7 | uint64(b2)<<14
+				return int64(uv>>1) ^ -int64(uv&1)
+			}
+		}
+	}
+	return s.getVarIntSlow()
+}
+
+//go:noinline
+func (s *Serializer) getVarIntSlow() int64 {
 	ret, l := binary.Varint(s.buf[s.pos:])
 	s.pos += l
 	return ret

--- a/cjson/serializer.go
+++ b/cjson/serializer.go
@@ -303,10 +303,11 @@ func (s *Serializer) WriteFloat64s(v []float64) (n int, err error) {
 }
 
 func (s *Serializer) PutVarInt(v int64) {
-	l := len(s.buf)
-	s.grow(10)
-	rl := binary.PutVarint(s.buf[l:], v)
-	s.buf = s.buf[:rl+l]
+	uv := uint64(v) << 1
+	if v < 0 {
+		uv = ^uv
+	}
+	s.PutVarUInt(uv)
 }
 
 func (s *Serializer) PutVarUInt(v uint64) *Serializer {
@@ -343,7 +344,7 @@ func (s *Serializer) PutVString(v string) *Serializer {
 	s.PutVarUInt(uint64(sl))
 	l := len(s.buf)
 	s.grow(sl)
-	copy(s.buf[l:], []byte(v))
+	copy(s.buf[l:], v)
 	return s
 }
 func (s *Serializer) Truncate(pos int) {
@@ -474,6 +475,13 @@ func (s *Serializer) GetUuid() string {
 }
 
 func (s *Serializer) GetVarInt() int64 {
+	if s.pos < len(s.buf) {
+		if b := s.buf[s.pos]; b < 0x80 {
+			s.pos++
+			uv := uint64(b)
+			return int64(uv>>1) ^ -int64(uv&1)
+		}
+	}
 	ret, l := binary.Varint(s.buf[s.pos:])
 	s.pos += l
 	return ret

--- a/cjson/serializer.go
+++ b/cjson/serializer.go
@@ -373,11 +373,23 @@ func (s *Serializer) TruncateStart(pos int) {
 }
 
 func (s *Serializer) GetUInt16() (v uint16) {
-	return uint16(s.readIntBits(unsafe.Sizeof(v)))
+	pos := s.pos
+	if pos+2 > len(s.buf) {
+		s.readSizePanic(2)
+	}
+	v = binary.LittleEndian.Uint16(s.buf[pos:])
+	s.pos = pos + 2
+	return v
 }
 
 func (s *Serializer) GetUInt32() (v uint32) {
-	return uint32(s.readIntBits(unsafe.Sizeof(v)))
+	pos := s.pos
+	if pos+4 > len(s.buf) {
+		s.readSizePanic(4)
+	}
+	v = binary.LittleEndian.Uint32(s.buf[pos:])
+	s.pos = pos + 4
+	return v
 }
 
 func (s *Serializer) GetCArrayTag() carraytag {
@@ -385,7 +397,13 @@ func (s *Serializer) GetCArrayTag() carraytag {
 }
 
 func (s *Serializer) GetUInt64() (v uint64) {
-	return s.readUIntBits(unsafe.Sizeof(v))
+	pos := s.pos
+	if pos+8 > len(s.buf) {
+		s.readSizePanic(8)
+	}
+	v = binary.LittleEndian.Uint64(s.buf[pos:])
+	s.pos = pos + 8
+	return v
 }
 
 func (s *Serializer) GetDouble() (v float64) {
@@ -440,50 +458,6 @@ func (s *Serializer) SkipVString() {
 //go:noinline
 func (s *Serializer) readSizePanic(sz int) {
 	panic(fmt.Errorf("Internal error: serializer need %d bytes, but only %d available", s.pos+sz, len(s.buf)-s.pos))
-}
-
-func (s *Serializer) readIntBits(sz uintptr) (v int64) {
-	if s.pos+int(sz) > len(s.buf) {
-		panic(fmt.Errorf("Internal error: serializer need %d bytes, but only %d available", s.pos+int(sz), len(s.buf)-s.pos))
-	}
-	switch sz {
-	case 1:
-		v = int64(s.buf[s.pos])
-	case 2:
-		v = int64(binary.LittleEndian.Uint16(s.buf[s.pos:]))
-	case 4:
-		v = int64(binary.LittleEndian.Uint32(s.buf[s.pos:]))
-	case 8:
-		v = int64(binary.LittleEndian.Uint64(s.buf[s.pos:]))
-	default:
-		for i := int(sz) - 1; i >= 0; i-- {
-			v = (int64(s.buf[i+s.pos]) & 0xFF) | (v << 8)
-		}
-	}
-	s.pos += int(sz)
-	return v
-}
-func (s *Serializer) readUIntBits(sz uintptr) (v uint64) {
-	if s.pos+int(sz) > len(s.buf) {
-		panic(fmt.Errorf("Internal error: serializer need %d bytes, but only %d available", s.pos+int(sz), len(s.buf)-s.pos))
-	}
-	switch sz {
-	case 1:
-		v = uint64(s.buf[s.pos])
-	case 2:
-		v = uint64(binary.LittleEndian.Uint16(s.buf[s.pos:]))
-	case 4:
-		v = uint64(binary.LittleEndian.Uint32(s.buf[s.pos:]))
-	case 8:
-		v = binary.LittleEndian.Uint64(s.buf[s.pos:])
-	default:
-		for i := int(sz) - 1; i >= 0; i-- {
-			v = (uint64(s.buf[i+s.pos]) & 0xFF) | (v << 8)
-		}
-
-	}
-	s.pos += int(sz)
-	return v
 }
 
 func (s *Serializer) GetVarUInt() uint64 {

--- a/cjson/serializer_micro_bench_test.go
+++ b/cjson/serializer_micro_bench_test.go
@@ -10,6 +10,7 @@ import (
 var (
 	benchUint64Sink uint64
 	benchBytesSink  []byte
+	benchStringSink string
 )
 
 func benchmarkSerializerBytesOp(b *testing.B, op func(*Serializer, []byte), headerReserve int) {
@@ -149,6 +150,34 @@ func BenchmarkSerializerPutUuid(b *testing.B) {
 		ser.PutUuid(uuid)
 	}
 	benchBytesSink = ser.Bytes()
+}
+
+func BenchmarkSerializerGetUuid(b *testing.B) {
+	uuid := [2]uint64{0x0102030405060708, 0x1112131415161718}
+	wr := NewSerializer(nil)
+	wr.PutUuid(uuid)
+	payload := wr.Bytes()
+	rd := NewSerializer(payload)
+
+	b.ReportAllocs()
+	b.SetBytes(16)
+	b.ResetTimer()
+	for b.Loop() {
+		if rd.pos >= len(rd.buf) {
+			rd.pos = 0
+		}
+		benchStringSink = rd.GetUuid()
+	}
+}
+
+func BenchmarkCreateUuid(b *testing.B) {
+	uuid := [2]uint64{0x0102030405060708, 0x1112131415161718}
+
+	b.ReportAllocs()
+	b.SetBytes(16)
+	for b.Loop() {
+		benchStringSink = createUuid(uuid)
+	}
 }
 
 func BenchmarkSerializerPutVBytes(b *testing.B) {

--- a/cjson/serializer_micro_bench_test.go
+++ b/cjson/serializer_micro_bench_test.go
@@ -193,6 +193,40 @@ func BenchmarkSerializerPutVString(b *testing.B) {
 	benchBytesSink = ser.Bytes()
 }
 
+func BenchmarkSerializerPutVarInt(b *testing.B) {
+	for _, value := range []int64{0, 42, -42, 8192, -8192} {
+		b.Run(fmt.Sprintf("value=%d", value), func(b *testing.B) {
+			ser := NewSerializer(make([]byte, 0, binary.MaxVarintLen64))
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				ser.Reset()
+				ser.PutVarInt(value)
+			}
+			benchBytesSink = ser.Bytes()
+		})
+	}
+}
+
+func BenchmarkSerializerGetVarInt(b *testing.B) {
+	for _, value := range []int64{0, 42, -42, 8192, -8192} {
+		b.Run(fmt.Sprintf("value=%d", value), func(b *testing.B) {
+			wr := NewSerializer(nil)
+			wr.PutVarInt(value)
+			payload := wr.Bytes()
+			rd := NewSerializer(payload)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if rd.pos >= len(rd.buf) {
+					rd.pos = 0
+				}
+				benchUint64Sink ^= uint64(rd.GetVarInt())
+			}
+		})
+	}
+}
+
 func BenchmarkSerializerReadUIntBits(b *testing.B) {
 	sizes := []uintptr{1, 2, 4, 8}
 	for _, sz := range sizes {

--- a/cjson/serializer_micro_bench_test.go
+++ b/cjson/serializer_micro_bench_test.go
@@ -170,6 +170,60 @@ func BenchmarkSerializerGetUuid(b *testing.B) {
 	}
 }
 
+func BenchmarkSerializerGetUInt16(b *testing.B) {
+	wr := NewSerializer(nil)
+	for i := 0; i < 4096; i++ {
+		wr.PutUInt16(uint16(i))
+	}
+	rd := NewSerializer(wr.Bytes())
+
+	b.ReportAllocs()
+	b.SetBytes(2)
+	b.ResetTimer()
+	for b.Loop() {
+		if rd.pos+2 > len(rd.buf) {
+			rd.pos = 0
+		}
+		benchUint64Sink ^= uint64(rd.GetUInt16())
+	}
+}
+
+func BenchmarkSerializerGetUInt32(b *testing.B) {
+	wr := NewSerializer(nil)
+	for i := 0; i < 4096; i++ {
+		wr.PutUInt32(uint32(i))
+	}
+	rd := NewSerializer(wr.Bytes())
+
+	b.ReportAllocs()
+	b.SetBytes(4)
+	b.ResetTimer()
+	for b.Loop() {
+		if rd.pos+4 > len(rd.buf) {
+			rd.pos = 0
+		}
+		benchUint64Sink ^= uint64(rd.GetUInt32())
+	}
+}
+
+func BenchmarkSerializerGetUInt64(b *testing.B) {
+	wr := NewSerializer(nil)
+	for i := 0; i < 4096; i++ {
+		wr.PutUInt64(uint64(i))
+	}
+	rd := NewSerializer(wr.Bytes())
+
+	b.ReportAllocs()
+	b.SetBytes(8)
+	b.ResetTimer()
+	for b.Loop() {
+		if rd.pos+8 > len(rd.buf) {
+			rd.pos = 0
+		}
+		benchUint64Sink ^= rd.GetUInt64()
+	}
+}
+
 func BenchmarkCreateUuid(b *testing.B) {
 	uuid := [2]uint64{0x0102030405060708, 0x1112131415161718}
 
@@ -251,29 +305,6 @@ func BenchmarkSerializerGetVarInt(b *testing.B) {
 					rd.pos = 0
 				}
 				benchUint64Sink ^= uint64(rd.GetVarInt())
-			}
-		})
-	}
-}
-
-func BenchmarkSerializerReadUIntBits(b *testing.B) {
-	sizes := []uintptr{1, 2, 4, 8}
-	for _, sz := range sizes {
-		b.Run(fmt.Sprintf("size=%d", sz), func(b *testing.B) {
-			wr := NewSerializer(nil)
-			for i := 0; i < 4096; i++ {
-				wr.writeIntBits(int64(i), sz)
-			}
-			rd := NewSerializer(wr.Bytes())
-
-			b.ReportAllocs()
-			b.SetBytes(int64(sz))
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
-				if rd.pos+int(sz) > len(rd.buf) {
-					rd.pos = 0
-				}
-				benchUint64Sink ^= rd.readUIntBits(sz)
 			}
 		})
 	}

--- a/cjson/serializer_test.go
+++ b/cjson/serializer_test.go
@@ -88,7 +88,8 @@ func TestSerializerReadWriteFixedWidthRoundTrip(t *testing.T) {
 	ser.PutFloat32(1.25).PutDouble(-15.5)
 
 	rd := NewSerializer(ser.Bytes())
-	assert.EqualValues(t, 7, rd.readUIntBits(1))
+	assert.EqualValues(t, 7, rd.buf[rd.pos])
+	rd.pos++
 	assert.EqualValues(t, 513, rd.GetUInt16())
 	assert.EqualValues(t, 1024, rd.GetUInt32())
 	assert.EqualValues(t, 1<<40+5, rd.GetUInt64())

--- a/iterator.go
+++ b/iterator.go
@@ -225,7 +225,9 @@ func (it *Iterator) setBuffer(result bindings.RawBuffer, cleanup bool) {
 	it.ser = newSerializer(result.GetBuf())
 	it.result = result
 	if cleanup {
-		it.rawQueryParams = it.ser.readRawQueryParams(func(nsid int) {
+		nsIncarnationTags := it.rawQueryParams.nsIncarnationTags
+		it.rawQueryParams = rawResultQueryParams{nsIncarnationTags: nsIncarnationTags}
+		it.ser.readRawQueryParamsResetMissingExtras(&it.rawQueryParams, func(nsid int) {
 			it.nsArray[nsid].localCjsonState = it.nsArray[nsid].cjsonState.ReadPayloadType(&it.ser.Serializer, it.db.binding, it.nsArray[nsid].name)
 		})
 	} else {
@@ -409,11 +411,26 @@ func (it *Iterator) join(nsIndex, nsIndexOffset, parentNsID int, item any) error
 			return bindings.NewError(fmt.Sprintf("can not find field with tag '%s' in struct '%s' for put join results from '%s'",
 				field, it.nsArray[0].rtype, it.nsArray[nsIndex+nsIndexOffset].name), ErrCodeLogic)
 		}
+		oldLen := v.Len()
+		newLen := oldLen + len(subitems)
 		if v.IsNil() {
-			v.Set(reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(it.nsArray[nsIndex+nsIndexOffset].rtype)), 0, len(subitems)))
+			v.Set(reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(it.nsArray[nsIndex+nsIndexOffset].rtype)), newLen, newLen))
+		} else if newLen <= v.Cap() {
+			v.Set(v.Slice(0, newLen))
+		} else {
+			newCap := newLen
+			if oldCap := v.Cap(); oldCap > 0 {
+				newCap = oldCap * 2
+				if newCap < newLen {
+					newCap = newLen
+				}
+			}
+			nv := reflect.MakeSlice(v.Type(), newLen, newCap)
+			reflect.Copy(nv, v)
+			v.Set(nv)
 		}
-		for _, subitem := range subitems {
-			v.Set(reflect.Append(v, reflect.ValueOf(subitem)))
+		for i, subitem := range subitems {
+			v.Index(oldLen + i).Set(reflect.ValueOf(subitem))
 		}
 	}
 	return nil

--- a/iterator.go
+++ b/iterator.go
@@ -174,6 +174,9 @@ func newIterator(
 	if joinObjSize > 0 {
 		it.current.joinObj = make([][]any, joinObjSize)
 	}
+	if len(it.joinFields) > 0 {
+		it.clearJoinFieldCache()
+	}
 	it.setBuffer(result, true)
 
 	return
@@ -207,6 +210,7 @@ type Iterator struct {
 	nsArray        []nsArrayEntry
 	joinToFields   []string
 	joinHandlers   []JoinHandler
+	joinFields     [][]joinedFieldInfo
 	queryContext   any
 	query          *Query
 	allowUnsafe    bool
@@ -219,6 +223,89 @@ type Iterator struct {
 	}
 	err     error
 	userCtx context.Context
+}
+
+type joinedFieldInfo struct {
+	index    []int
+	hasIndex bool
+}
+
+func (it *Iterator) clearJoinFieldCache() {
+	for i := range it.joinFields {
+		it.joinFields[i] = it.joinFields[i][:0]
+	}
+	it.joinFields = it.joinFields[:0]
+}
+
+func (it *Iterator) resetJoinFieldCache(joinObjSize int) {
+	if joinObjSize == 0 {
+		joinObjSize = len(it.joinToFields)
+		if it.query != nil {
+			for _, mq := range it.query.mergedQueries {
+				if len(mq.joinToFields) > joinObjSize {
+					joinObjSize = len(mq.joinToFields)
+				}
+			}
+		}
+		if joinObjSize == 0 {
+			it.joinFields = it.joinFields[:0]
+			return
+		}
+	}
+
+	parentCount := 1
+	if it.query != nil {
+		parentCount += len(it.query.mergedQueries)
+	}
+	if cap(it.joinFields) < parentCount {
+		it.joinFields = make([][]joinedFieldInfo, parentCount)
+	} else {
+		it.joinFields = it.joinFields[:parentCount]
+		for i := range it.joinFields {
+			it.joinFields[i] = it.joinFields[i][:0]
+		}
+	}
+	it.fillJoinFieldCache(0, it.joinToFields)
+	if it.query != nil {
+		for i, mq := range it.query.mergedQueries {
+			it.fillJoinFieldCache(i+1, mq.joinToFields)
+		}
+	}
+}
+
+func (it *Iterator) fillJoinFieldCache(parentNsID int, fields []string) {
+	if parentNsID >= len(it.joinFields) {
+		return
+	}
+	infos := it.joinFields[parentNsID]
+	if cap(infos) < len(fields) {
+		infos = make([]joinedFieldInfo, len(fields))
+	} else {
+		infos = infos[:len(fields)]
+	}
+	var joined map[string][]int
+	if parentNsID < len(it.nsArray) {
+		joined = it.nsArray[parentNsID].joined
+	}
+	for i, field := range fields {
+		var info joinedFieldInfo
+		if idx, ok := joined[field]; ok {
+			info.index = idx
+			info.hasIndex = true
+		}
+		infos[i] = info
+	}
+	it.joinFields[parentNsID] = infos
+}
+
+func (it *Iterator) getJoinFieldInfo(parentNsID, nsIndex int) (joinedFieldInfo, bool) {
+	if len(it.joinFields) == 0 {
+		it.resetJoinFieldCache(0)
+	}
+	if parentNsID < len(it.joinFields) && nsIndex < len(it.joinFields[parentNsID]) {
+		return it.joinFields[parentNsID][nsIndex], true
+	}
+	return joinedFieldInfo{}, false
 }
 
 func (it *Iterator) setBuffer(result bindings.RawBuffer, cleanup bool) {
@@ -406,34 +493,45 @@ func (it *Iterator) join(nsIndex, nsIndexOffset, parentNsID int, item any) error
 				field, it.nsArray[0].rtype, it.nsArray[nsIndex+nsIndexOffset].name), ErrCodeStrictMode)
 		}
 	} else {
-		v := getJoinedField(reflect.ValueOf(item), it.nsArray[parentNsID].joined, field)
+		var v reflect.Value
+		info, hasInfo := it.getJoinFieldInfo(parentNsID, nsIndex)
+		if hasInfo && info.hasIndex {
+			v = joinedFieldByIndex(reflect.ValueOf(item), info.index)
+		} else {
+			v = getJoinedField(reflect.ValueOf(item), it.nsArray[parentNsID].joined, field)
+		}
 		if !v.IsValid() {
 			return bindings.NewError(fmt.Sprintf("can not find field with tag '%s' in struct '%s' for put join results from '%s'",
 				field, it.nsArray[0].rtype, it.nsArray[nsIndex+nsIndexOffset].name), ErrCodeLogic)
 		}
-		oldLen := v.Len()
-		newLen := oldLen + len(subitems)
-		if v.IsNil() {
-			v.Set(reflect.MakeSlice(reflect.SliceOf(reflect.PointerTo(it.nsArray[nsIndex+nsIndexOffset].rtype)), newLen, newLen))
-		} else if newLen <= v.Cap() {
-			v.Set(v.Slice(0, newLen))
-		} else {
-			newCap := newLen
-			if oldCap := v.Cap(); oldCap > 0 {
-				newCap = oldCap * 2
-				if newCap < newLen {
-					newCap = newLen
-				}
-			}
-			nv := reflect.MakeSlice(v.Type(), newLen, newCap)
-			reflect.Copy(nv, v)
-			v.Set(nv)
-		}
+		oldLen := growJoinedSlice(v, len(subitems))
 		for i, subitem := range subitems {
 			v.Index(oldLen + i).Set(reflect.ValueOf(subitem))
 		}
 	}
 	return nil
+}
+
+func growJoinedSlice(v reflect.Value, add int) int {
+	oldLen := v.Len()
+	newLen := oldLen + add
+	if v.IsNil() {
+		v.Set(reflect.MakeSlice(v.Type(), newLen, newLen))
+	} else if newLen <= v.Cap() {
+		v.Set(v.Slice(0, newLen))
+	} else {
+		newCap := newLen
+		if oldCap := v.Cap(); oldCap > 0 {
+			newCap = oldCap * 2
+			if newCap < newLen {
+				newCap = newLen
+			}
+		}
+		nv := reflect.MakeSlice(v.Type(), newLen, newCap)
+		reflect.Copy(nv, v)
+		v.Set(nv)
+	}
+	return oldLen
 }
 
 // Object returns current object.

--- a/query.go
+++ b/query.go
@@ -560,9 +560,6 @@ func (q *Query) finishWhere() *Query {
 // - slice/arrays of values
 // - nil for CondAny/CondEmpty
 func (q *Query) WhereQuery(subQuery *Query, condition int, keys any) *Query {
-	t := reflect.TypeOf(keys)
-	v := reflect.ValueOf(keys)
-
 	q.ser.PutVarCUInt(querySubQueryCondition)
 	q.ser.PutVarCUInt(q.nextOp)
 	q.ser.PutVBytes(subQuery.ser.Bytes())
@@ -572,7 +569,12 @@ func (q *Query) WhereQuery(subQuery *Query, condition int, keys any) *Query {
 
 	if keys == nil {
 		q.ser.PutVarUInt(0)
-	} else if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
+		return q
+	}
+
+	t := reflect.TypeOf(keys)
+	v := reflect.ValueOf(keys)
+	if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		q.ser.PutVarCUInt(v.Len())
 		for i := range v.Len() {
 			q.ser.PutValue(v.Index(i))

--- a/query.go
+++ b/query.go
@@ -169,6 +169,7 @@ type Query struct {
 	tmVersions        []int32
 	iterator          Iterator
 	jsonIterator      JSONIterator
+	aggregateFacet    AggregateFacetRequest
 	items             []any
 	json              []byte
 	jsonOffsets       []int
@@ -284,12 +285,10 @@ func init() {
 }
 
 func mktrace(buf *[]byte) {
-	if enableDebug {
-		if *buf == nil {
-			*buf = make([]byte, 0x4000)
-		}
-		*buf = (*buf)[0:runtime.Stack((*buf)[0:cap((*buf))], false)]
+	if *buf == nil {
+		*buf = make([]byte, 0x4000)
 	}
+	*buf = (*buf)[0:runtime.Stack((*buf)[0:cap((*buf))], false)]
 }
 
 // Create new DB query
@@ -321,7 +320,9 @@ func newQuery(db *reindexerImpl, namespace string, tx *Tx) *Query {
 		q.whereEntriesCount = 0
 		q.openedBrackets = q.openedBrackets[:0]
 	}
-	mktrace(&q.traceNew)
+	if enableDebug {
+		mktrace(&q.traceNew)
+	}
 
 	q.Namespace = namespace
 	q.db = db
@@ -348,7 +349,9 @@ func (q *Query) makeCopy(db *reindexerImpl, root *Query) *Query {
 	if qC == nil {
 		qC = &Query{}
 	}
-	mktrace(&qC.traceNew)
+	if enableDebug {
+		mktrace(&qC.traceNew)
+	}
 
 	qC.ser = cjson.NewSerializer(qC.initBuf[:0])
 
@@ -400,38 +403,153 @@ func (q *Query) makeCopy(db *reindexerImpl, root *Query) *Query {
 // - []interface{} with 1 value per subindex for composite indexes
 // - *Query for subquery where-filters
 func (q *Query) Where(index string, condition int, keys any) *Query {
-	t := reflect.TypeOf(keys)
+	switch v := keys.(type) {
+	case nil:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarUInt(0)
+		return q.finishWhere()
+	case *Query:
+		q.putSubQueryWhere(index, condition, v.ser.Bytes())
+		return q.finishWhere()
+	case Query:
+		q.putSubQueryWhere(index, condition, v.ser.Bytes())
+		return q.finishWhere()
+	case int:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.putIntValue(v)
+		return q.finishWhere()
+	case int32:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.ser.PutVarCUInt(valueInt).PutVarInt(int64(v))
+		return q.finishWhere()
+	case int64:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.ser.PutVarCUInt(valueInt64).PutVarInt(v)
+		return q.finishWhere()
+	case string:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.ser.PutVarCUInt(valueString).PutVString(v)
+		return q.finishWhere()
+	case bool:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.putBoolValue(v)
+		return q.finishWhere()
+	case float32:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.ser.PutVarCUInt(valueDouble).PutDouble(float64(v))
+		return q.finishWhere()
+	case float64:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(1)
+		q.ser.PutVarCUInt(valueDouble).PutDouble(v)
+		return q.finishWhere()
+	case []int:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.putIntValue(value)
+		}
+		return q.finishWhere()
+	case []int32:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarCUInt(valueInt).PutVarInt(int64(value))
+		}
+		return q.finishWhere()
+	case []int64:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarCUInt(valueInt64).PutVarInt(value)
+		}
+		return q.finishWhere()
+	case []string:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarCUInt(valueString).PutVString(value)
+		}
+		return q.finishWhere()
+	case []bool:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.putBoolValue(value)
+		}
+		return q.finishWhere()
+	case []float32:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarCUInt(valueDouble).PutDouble(float64(value))
+		}
+		return q.finishWhere()
+	case []float64:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarCUInt(valueDouble).PutDouble(value)
+		}
+		return q.finishWhere()
+	case []any:
+		q.putWhereHeader(index, condition)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutValue(reflect.ValueOf(value))
+		}
+		return q.finishWhere()
+	}
+
 	v := reflect.ValueOf(keys)
 
-	if keys != nil && (t == reflect.TypeFor[Query]() || (t.Kind() == reflect.Pointer && t.Elem() == reflect.TypeFor[Query]())) {
-		q.ser.PutVarCUInt(queryFieldSubQueryCondition)
-		q.ser.PutVarCUInt(q.nextOp)
-		q.ser.PutVString(index)
-		q.ser.PutVarCUInt(condition)
-		if t.Kind() == reflect.Pointer {
-			q.ser.PutVBytes(v.Interface().(*Query).ser.Bytes())
-		} else {
-			ser := v.FieldByName("ser").Interface().(cjson.Serializer)
-			q.ser.PutVBytes(ser.Bytes())
+	q.putWhereHeader(index, condition)
+	if k := v.Kind(); k == reflect.Slice || k == reflect.Array {
+		l := v.Len()
+		q.ser.PutVarCUInt(l)
+		for i := range l {
+			q.ser.PutValue(v.Index(i))
 		}
-	} else {
-		q.ser.PutVarCUInt(queryCondition)
-		q.ser.PutVString(index)
-		q.ser.PutVarCUInt(q.nextOp)
-		q.ser.PutVarCUInt(condition)
-
-		if keys == nil {
-			q.ser.PutVarUInt(0)
-		} else if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
-			q.ser.PutVarCUInt(v.Len())
-			for i := 0; i < v.Len(); i++ {
-				q.ser.PutValue(v.Index(i))
-			}
-		} else {
-			q.ser.PutVarCUInt(1)
-			q.ser.PutValue(v)
-		}
+		return q.finishWhere()
 	}
+
+	q.ser.PutVarCUInt(1)
+	q.ser.PutValue(v)
+	return q.finishWhere()
+}
+
+func (q *Query) putWhereHeader(index string, condition int) {
+	q.ser.PutVarCUInt(queryCondition).PutVString(index).PutVarCUInt(q.nextOp).PutVarCUInt(condition)
+}
+
+func (q *Query) putSubQueryWhere(index string, condition int, data []byte) {
+	q.ser.PutVarCUInt(queryFieldSubQueryCondition).PutVarCUInt(q.nextOp).PutVString(index).PutVarCUInt(condition).PutVBytes(data)
+}
+
+func (q *Query) putIntValue(v int) {
+	if strconv.IntSize == 64 {
+		q.ser.PutVarCUInt(valueInt64).PutVarInt(int64(v))
+	} else {
+		q.ser.PutVarCUInt(valueInt).PutVarInt(int64(v))
+	}
+}
+
+func (q *Query) putBoolValue(v bool) {
+	q.ser.PutVarCUInt(valueBool)
+	if v {
+		q.ser.PutVarUInt(1)
+	} else {
+		q.ser.PutVarUInt(0)
+	}
+}
+
+func (q *Query) finishWhere() *Query {
 	q.whereEntriesCount++
 	q.nextOp = opAND
 	return q
@@ -456,7 +574,7 @@ func (q *Query) WhereQuery(subQuery *Query, condition int, keys any) *Query {
 		q.ser.PutVarUInt(0)
 	} else if t.Kind() == reflect.Slice || t.Kind() == reflect.Array {
 		q.ser.PutVarCUInt(v.Len())
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			q.ser.PutValue(v.Index(i))
 		}
 	} else {
@@ -701,8 +819,8 @@ func (q *Query) AggregateFacet(fields ...string) *AggregateFacetRequest {
 	for _, f := range fields {
 		q.ser.PutVString(f)
 	}
-	r := AggregateFacetRequest{q}
-	return &r
+	q.aggregateFacet.query = q
+	return &q.aggregateFacet
 }
 
 func (r *AggregateFacetRequest) setAggregateType(aggregateType int, value int) *AggregateFacetRequest {
@@ -925,18 +1043,24 @@ func (q *Query) close() {
 	if q.closed {
 		q.panicTrace("Close call on already closed query")
 	}
-	mktrace(&q.traceClose)
+	if enableDebug {
+		mktrace(&q.traceClose)
+	}
 
 	for i, jq := range q.joinQueries {
 		jq.closed = true
-		mktrace(&jq.traceClose)
+		if enableDebug {
+			mktrace(&jq.traceClose)
+		}
 		queryPool.Put(jq)
 		q.joinQueries[i] = nil
 	}
 
 	for i, mq := range q.mergedQueries {
 		mq.closed = true
-		mktrace(&mq.traceClose)
+		if enableDebug {
+			mktrace(&mq.traceClose)
+		}
 		queryPool.Put(mq)
 		q.mergedQueries[i] = nil
 	}
@@ -985,26 +1109,37 @@ func (q *Query) DeleteCtx(ctx context.Context) (int, error) {
 	return q.db.deleteQuery(ctx, q)
 }
 
-func getValueJSON(value any) string {
-	ok := false
-	var err error
-	var objectJSON []byte
-	t := reflect.TypeOf(value)
+var emptyObjectJSON = []byte("{}")
+
+func getValueJSON(value any) []byte {
 	if value == nil {
-		objectJSON = []byte("{}")
-	} else if t.Kind() == reflect.Struct || t.Kind() == reflect.Map {
-		objectJSON, err = json.Marshal(value)
+		return emptyObjectJSON
+	}
+	if objectJSON, ok := value.([]byte); ok {
+		return objectJSON
+	}
+	t := reflect.TypeOf(value)
+	if t.Kind() == reflect.Struct || t.Kind() == reflect.Map {
+		objectJSON, err := json.Marshal(value)
 		if err != nil {
 			panic(err)
 		}
-	} else if objectJSON, ok = value.([]byte); !ok {
-		panic(errors.New("SetObject doesn't support this type of objects: " + t.Kind().String()))
+		return objectJSON
 	}
-	return string(objectJSON)
+	panic(errors.New("SetObject doesn't support this type of objects: " + t.Kind().String()))
 }
 
 // SetObject adds update of object field request for update query
 func (q *Query) SetObject(field string, values any) *Query {
+	switch v := values.(type) {
+	case nil:
+		return q.putSetObjectBytes(field, emptyObjectJSON)
+	case []byte:
+		return q.putSetObjectBytes(field, v)
+	case [][]byte:
+		return q.putSetObjectBytesArray(field, v)
+	}
+
 	size := 1
 	isArray := false
 	t := reflect.TypeOf(values)
@@ -1013,15 +1148,32 @@ func (q *Query) SetObject(field string, values any) *Query {
 		size = v.Len()
 		isArray = true
 	}
-	jsonValues := make([]string, size)
+	var jsonValue []byte
+	var jsonValues [][]byte
 	if isArray {
-		for i := 0; i < size; i++ {
+		jsonValues = make([][]byte, size)
+		for i := range size {
 			jsonValues[i] = getValueJSON(v.Index(i).Interface())
 		}
 	} else if size > 0 {
-		jsonValues[0] = getValueJSON(values)
+		jsonValue = getValueJSON(values)
+	}
+	q.putSetObjectHeader(field, size, isArray)
+	for i := range size {
+		// function/value flag
+		q.ser.PutVarUInt(0)
+		q.ser.PutVarCUInt(valueString)
+		if isArray {
+			q.ser.PutVBytes(jsonValues[i])
+		} else {
+			q.ser.PutVBytes(jsonValue)
+		}
 	}
 
+	return q
+}
+
+func (q *Query) putSetObjectHeader(field string, size int, isArray bool) {
 	q.ser.PutVarCUInt(queryUpdateObject)
 	q.ser.PutVString(field)
 
@@ -1033,18 +1185,122 @@ func (q *Query) SetObject(field string, values any) *Query {
 	} else {
 		q.ser.PutVarCUInt(0)
 	}
-	for i := 0; i < size; i++ {
-		// function/value flag
+}
+
+func (q *Query) putSetObjectBytes(field string, value []byte) *Query {
+	q.putSetObjectHeader(field, 1, false)
+	q.ser.PutVarUInt(0)
+	q.ser.PutVarCUInt(valueString)
+	q.ser.PutVBytes(value)
+	return q
+}
+
+func (q *Query) putSetObjectBytesArray(field string, values [][]byte) *Query {
+	q.putSetObjectHeader(field, len(values), true)
+	for _, value := range values {
 		q.ser.PutVarUInt(0)
 		q.ser.PutVarCUInt(valueString)
-		q.ser.PutVString(jsonValues[i])
+		q.ser.PutVBytes(value)
 	}
-
 	return q
 }
 
 // Set adds update field request for update query
 func (q *Query) Set(field string, values any) *Query {
+	switch v := values.(type) {
+	case int:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.putIntValue(v)
+		return q
+	case int32:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.ser.PutVarCUInt(valueInt).PutVarInt(int64(v))
+		return q
+	case int64:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.ser.PutVarCUInt(valueInt64).PutVarInt(v)
+		return q
+	case string:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.ser.PutVarCUInt(valueString).PutVString(v)
+		return q
+	case bool:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.putBoolValue(v)
+		return q
+	case float32:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.ser.PutVarCUInt(valueDouble).PutDouble(float64(v))
+		return q
+	case float64:
+		q.putSetHeader(field, queryUpdateField, false)
+		q.ser.PutVarCUInt(1).PutVarUInt(0)
+		q.ser.PutVarCUInt(valueDouble).PutDouble(v)
+		return q
+	case []int:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.putIntValue(value)
+		}
+		return q
+	case []int32:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.ser.PutVarCUInt(valueInt).PutVarInt(int64(value))
+		}
+		return q
+	case []int64:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.ser.PutVarCUInt(valueInt64).PutVarInt(value)
+		}
+		return q
+	case []string:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.ser.PutVarCUInt(valueString).PutVString(value)
+		}
+		return q
+	case []bool:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.putBoolValue(value)
+		}
+		return q
+	case []float32:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.ser.PutVarCUInt(valueDouble).PutDouble(float64(value))
+		}
+		return q
+	case []float64:
+		q.putSetHeader(field, setCmdForLen(len(v)), true)
+		q.ser.PutVarCUInt(len(v))
+		for _, value := range v {
+			q.ser.PutVarUInt(0)
+			q.ser.PutVarCUInt(valueDouble).PutDouble(value)
+		}
+		return q
+	}
+
 	t := reflect.TypeOf(values)
 	if t.Kind() == reflect.Struct || t.Kind() == reflect.Map {
 		return q.SetObject(field, values)
@@ -1074,7 +1330,7 @@ func (q *Query) Set(field string, values any) *Query {
 			q.ser.PutVarUInt(1) // is array
 		}
 		q.ser.PutVarCUInt(v.Len())
-		for i := 0; i < v.Len(); i++ {
+		for i := range v.Len() {
 			// function/value flag
 			q.ser.PutVarUInt(0)
 			q.ser.PutValue(v.Index(i))
@@ -1089,6 +1345,25 @@ func (q *Query) Set(field string, values any) *Query {
 		q.ser.PutValue(v)
 	}
 	return q
+}
+
+func setCmdForLen(l int) int {
+	if l <= 1 {
+		return queryUpdateFieldV2
+	}
+	return queryUpdateField
+}
+
+func (q *Query) putSetHeader(field string, cmd int, isArray bool) {
+	q.ser.PutVarCUInt(cmd)
+	q.ser.PutVString(field)
+	if cmd == queryUpdateFieldV2 {
+		if isArray {
+			q.ser.PutVarUInt(1)
+		} else {
+			q.ser.PutVarUInt(0)
+		}
+	}
 }
 
 // Drop removes field from item within Update statement

--- a/reflect.go
+++ b/reflect.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"unsafe"
 
 	"github.com/restream/reindexer/v5/bindings"
@@ -42,6 +43,23 @@ type indexOptions struct {
 	isComposite bool
 }
 
+type parseIndexesCacheEntry struct {
+	indexDefs []bindings.IndexDef
+	joined    map[string][]int
+}
+
+var (
+	parseIndexesCache sync.Map // map[reflect.Type]*parseIndexesCacheEntry
+	parseSchemaCache  sync.Map // map[reflect.Type]*bindings.SchemaDef
+)
+
+func normalizedStructType(st reflect.Type) reflect.Type {
+	if st.Kind() == reflect.Pointer {
+		return st.Elem()
+	}
+	return st
+}
+
 func parseRxTags(field reflect.StructField) (idxName string, idxType string, idxSettings []string) {
 	tag, isSet := field.Tag.Lookup("reindex")
 	tagsSlice := strings.SplitN(tag, ",", 3)
@@ -62,14 +80,42 @@ func parseRxTags(field reflect.StructField) (idxName string, idxType string, idx
 }
 
 func parseIndexes(st reflect.Type, joined *map[string][]int) (indexDefs []bindings.IndexDef, err error) {
-	if err = parseIndexesImpl(&indexDefs, st, false, "", "", joined, nil); err != nil {
+	st = normalizedStructType(st)
+	if joined != nil && *joined != nil && len(*joined) > 0 {
+		if err = parseIndexesImpl(&indexDefs, st, false, "", "", joined, nil); err != nil {
+			return nil, err
+		}
+		return indexDefs, nil
+	}
+
+	if cached, ok := parseIndexesCache.Load(st); ok {
+		entry := cached.(*parseIndexesCacheEntry)
+		if joined != nil {
+			*joined = entry.joined
+		}
+		return entry.indexDefs, nil
+	}
+
+	joinedMap := make(map[string][]int)
+	if err = parseIndexesImpl(&indexDefs, st, false, "", "", &joinedMap, nil); err != nil {
 		return nil, err
 	}
 
-	return indexDefs, nil
+	entry := &parseIndexesCacheEntry{indexDefs: indexDefs, joined: joinedMap}
+	cached, _ := parseIndexesCache.LoadOrStore(st, entry)
+	entry = cached.(*parseIndexesCacheEntry)
+	if joined != nil {
+		*joined = entry.joined
+	}
+	return entry.indexDefs, nil
 }
 
 func parseSchema(st reflect.Type) *bindings.SchemaDef {
+	st = normalizedStructType(st)
+	if cached, ok := parseSchemaCache.Load(st); ok {
+		return cached.(*bindings.SchemaDef)
+	}
+
 	reflector := &jsonschema.Reflector{}
 	reflector.FieldIsInScheme = func(f reflect.StructField) bool {
 		_, _, idxSettings := parseRxTags(f)
@@ -82,7 +128,8 @@ func parseSchema(st reflect.Type) *bindings.SchemaDef {
 	reflector.FullyQualifyTypeNames = true
 	if schema := reflector.ReflectFromType(st); schema != nil {
 		schemaDef := bindings.SchemaDef(*schema)
-		return &schemaDef
+		cached, _ := parseSchemaCache.LoadOrStore(st, &schemaDef)
+		return cached.(*bindings.SchemaDef)
 	}
 	return nil
 }

--- a/reflect.go
+++ b/reflect.go
@@ -534,9 +534,13 @@ func getFieldType(t reflect.Type) (string, error) {
 	return "", errInvalidReflection
 }
 
+func joinedFieldByIndex(val reflect.Value, idx []int) reflect.Value {
+	return reflect.Indirect(reflect.Indirect(val).FieldByIndex(idx))
+}
+
 func getJoinedField(val reflect.Value, joined map[string][]int, name string) (ret reflect.Value) {
 	if idx, ok := joined[name]; ok {
-		ret = reflect.Indirect(reflect.Indirect(val).FieldByIndex(idx))
+		ret = joinedFieldByIndex(val, idx)
 	}
 	return ret
 }

--- a/reindexer_impl.go
+++ b/reindexer_impl.go
@@ -527,7 +527,6 @@ func (db *reindexerImpl) registerNamespaceImpl(namespace string, opts *Namespace
 		cacheItems:    cacheItems,
 		rtype:         t,
 		name:          namespace,
-		joined:        make(map[string][]int),
 		opts:          *opts,
 		cjsonState:    cjson.NewState(),
 		deepCopyIface: haveDeepCopy,

--- a/reindexer_perf_bench_test.go
+++ b/reindexer_perf_bench_test.go
@@ -91,6 +91,39 @@ func BenchmarkQueryBuildSliceWhere(b *testing.B) {
 	}
 }
 
+func BenchmarkQueryWhereQueryKeys(b *testing.B) {
+	b.Run("nil", func(b *testing.B) {
+		subQuery := newBenchPerfQuery().WhereInt("age", GE, 18)
+		defer subQuery.close()
+		for b.Loop() {
+			q := newBenchPerfQuery().WhereQuery(subQuery, SET, nil)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("scalar", func(b *testing.B) {
+		subQuery := newBenchPerfQuery().WhereInt("age", GE, 18)
+		defer subQuery.close()
+		for b.Loop() {
+			q := newBenchPerfQuery().WhereQuery(subQuery, SET, 42)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("slice", func(b *testing.B) {
+		keys := []int{1, 2, 3, 4, 5, 6, 7, 8}
+		subQuery := newBenchPerfQuery().WhereInt("age", GE, 18)
+		defer subQuery.close()
+		for b.Loop() {
+			q := newBenchPerfQuery().WhereQuery(subQuery, SET, keys)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+}
+
 func BenchmarkQueryBuildKnn(b *testing.B) {
 	vec := make([]float32, 256)
 	for i := range vec {
@@ -306,16 +339,19 @@ func BenchmarkReindexerPackItem(b *testing.B) {
 	}
 	ser := cjson.NewPoolSerializer()
 	defer ser.Close()
-	if _, _, err := packItem(ns, item, nil, ser); err != nil {
+	if _, _, _, err := packItem(ns, item, nil, ser); err != nil {
 		b.Fatal(err)
 	}
 
 	b.ReportAllocs()
 	for b.Loop() {
 		ser.Reset()
-		format, token, err := packItem(ns, item, nil, ser)
+		format, token, itemIsPtr, err := packItem(ns, item, nil, ser)
 		if err != nil {
 			b.Fatal(err)
+		}
+		if itemIsPtr {
+			benchPerfIntSink++
 		}
 		benchPerfIntSink += format + token + len(ser.Bytes())
 	}
@@ -334,9 +370,12 @@ func BenchmarkReindexerPackJSON(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		ser.Reset()
-		format, token, err := packItem(ns, nil, json, ser)
+		format, token, itemIsPtr, err := packItem(ns, nil, json, ser)
 		if err != nil {
 			b.Fatal(err)
+		}
+		if itemIsPtr {
+			b.Fatal("json packItem unexpectedly reported pointer item")
 		}
 		benchPerfIntSink += format + token + len(ser.Bytes())
 	}
@@ -443,9 +482,12 @@ func BenchmarkReindexerModifyPreceptsSerialize(b *testing.B) {
 	b.ReportAllocs()
 	for b.Loop() {
 		ser.Reset()
-		format, token, err := packItem(ns, item, nil, ser)
+		format, token, itemIsPtr, err := packItem(ns, item, nil, ser)
 		if err != nil {
 			b.Fatal(err)
+		}
+		if itemIsPtr {
+			benchPerfIntSink++
 		}
 		benchPerfIntSink += format + token + len(precepts) + len(ser.Bytes())
 	}

--- a/reindexer_perf_bench_test.go
+++ b/reindexer_perf_bench_test.go
@@ -1,0 +1,561 @@
+package reindexer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/restream/reindexer/v5/bindings"
+	"github.com/restream/reindexer/v5/cjson"
+)
+
+type benchPerfNested struct {
+	Code   int      `json:"code" reindex:"code,hash"`
+	Labels []string `json:"labels"`
+}
+
+type benchPerfJoined struct {
+	ID   int    `json:"id" reindex:"id,,pk"`
+	Name string `json:"name" reindex:"name,tree"`
+}
+
+type benchPerfItem struct {
+	ID      int                `json:"id" reindex:"id,,pk"`
+	Age     int                `json:"age" reindex:"age,tree"`
+	Score   int64              `json:"score" reindex:"score,hash"`
+	Price   float64            `json:"price" reindex:"price,tree"`
+	Active  bool               `json:"active" reindex:"active,hash"`
+	Name    string             `json:"name" reindex:"name,text"`
+	Tags    []string           `json:"tags" reindex:"tags,hash"`
+	Nums    []int              `json:"nums" reindex:"nums,hash"`
+	Vector  []float32          `json:"vector" reindex:"vector,vec_bf,metric=l2,dimension=8"`
+	Nested  benchPerfNested    `json:"nested"`
+	Joined  []*benchPerfJoined `json:"joined" reindex:"joined,,joined"`
+	Payload map[string]any     `json:"payload"`
+}
+
+type benchPerfJoinableItem struct {
+	benchPerfItem
+	joinedSink []any
+}
+
+func (i *benchPerfJoinableItem) Join(_ string, subitems []any, _ any) {
+	i.joinedSink = subitems
+}
+
+var (
+	benchPerfAnySink   any
+	benchPerfBytesSink []byte
+	benchPerfIntSink   int
+)
+
+func benchPerfKnnParam() KnnSearchParam {
+	k := 10
+	radius := float32(1.25)
+	p, err := NewIndexHnswSearchParam(64, BaseKnnSearchParam{K: &k, Radius: &radius})
+	if err != nil {
+		panic(err)
+	}
+	return p
+}
+
+func newBenchPerfQuery() *Query {
+	return newQuery(nil, "bench_items", nil)
+}
+
+func BenchmarkQueryBuildScalarWhere(b *testing.B) {
+	for b.Loop() {
+		q := newBenchPerfQuery().
+			Where("id", EQ, 42).
+			WhereString("name", EQ, "alice", "bob").
+			WhereInt("age", GE, 18, 21, 30).
+			WhereInt64("score", GT, 123456789).
+			Sort("age", false, 18, 21, 30).
+			Limit(20).
+			Offset(5)
+		benchPerfBytesSink = q.ser.Bytes()
+		q.close()
+	}
+}
+
+func BenchmarkQueryBuildSliceWhere(b *testing.B) {
+	keys := []int{1, 2, 3, 4, 5, 6, 7, 8}
+	strings := []string{"a", "b", "c", "d"}
+	for b.Loop() {
+		q := newBenchPerfQuery().
+			Where("id", SET, keys).
+			Where("name", SET, strings).
+			WhereComposite("id+name", EQ, []any{42, "alice"}).
+			Sort("id", true)
+		benchPerfBytesSink = q.ser.Bytes()
+		q.close()
+	}
+}
+
+func BenchmarkQueryBuildKnn(b *testing.B) {
+	vec := make([]float32, 256)
+	for i := range vec {
+		vec[i] = float32(i) * 0.125
+	}
+	param := benchPerfKnnParam()
+	for b.Loop() {
+		q := newBenchPerfQuery().
+			WhereKnn("vector", vec, param).
+			Sort("id", false).
+			Limit(10)
+		benchPerfBytesSink = q.ser.Bytes()
+		q.close()
+	}
+}
+
+func BenchmarkQueryBuildUpdateSet(b *testing.B) {
+	obj := benchPerfNested{Code: 7, Labels: []string{"hot", "path"}}
+	for b.Loop() {
+		q := newBenchPerfQuery().
+			WhereInt("id", EQ, 42).
+			Set("age", 43).
+			Set("tags", []string{"new", "tags"}).
+			SetObject("nested", obj)
+		benchPerfBytesSink = q.ser.Bytes()
+		q.close()
+	}
+}
+
+func BenchmarkQueryBuildJoinMergeCopy(b *testing.B) {
+	for b.Loop() {
+		q := newBenchPerfQuery().WhereInt("id", EQ, 42)
+		jq := newQuery(nil, "bench_joined", nil).WhereInt("id", EQ, 42)
+		mq := newQuery(nil, "bench_items_archive", nil).WhereString("name", EQ, "alice")
+		q.LeftJoin(jq, "joined").On("id", EQ, "id").Merge(mq)
+		qc := q.makeCopy(nil, nil)
+		benchPerfBytesSink = qc.ser.Bytes()
+		qc.close()
+		q.close()
+	}
+}
+
+func BenchmarkIteratorReflectJoin(b *testing.B) {
+	subitems := []any{
+		&benchPerfJoined{ID: 1, Name: "a"},
+		&benchPerfJoined{ID: 2, Name: "b"},
+		&benchPerfJoined{ID: 3, Name: "c"},
+	}
+	it := &Iterator{
+		query: &Query{db: &reindexerImpl{}},
+		nsArray: []nsArrayEntry{
+			{reindexerNamespace: &reindexerNamespace{rtype: reflect.TypeFor[benchPerfItem](), joined: map[string][]int{"joined": []int{10}}}},
+			{reindexerNamespace: &reindexerNamespace{name: "bench_joined", rtype: reflect.TypeFor[benchPerfJoined]()}},
+		},
+		joinToFields: []string{"joined"},
+		joinHandlers: []JoinHandler{nil},
+	}
+	it.current.joinObj = make([][]any, 1)
+
+	for b.Loop() {
+		item := &benchPerfItem{}
+		it.current.joinObj[0] = subitems
+		if err := it.join(0, 1, 0, item); err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += len(item.Joined)
+	}
+}
+
+func BenchmarkIteratorReflectJoinReuse(b *testing.B) {
+	subitems := []any{
+		&benchPerfJoined{ID: 1, Name: "a"},
+		&benchPerfJoined{ID: 2, Name: "b"},
+		&benchPerfJoined{ID: 3, Name: "c"},
+	}
+	it := &Iterator{
+		query: &Query{db: &reindexerImpl{}},
+		nsArray: []nsArrayEntry{
+			{reindexerNamespace: &reindexerNamespace{rtype: reflect.TypeFor[benchPerfItem](), joined: map[string][]int{"joined": []int{10}}}},
+			{reindexerNamespace: &reindexerNamespace{name: "bench_joined", rtype: reflect.TypeFor[benchPerfJoined]()}},
+		},
+		joinToFields: []string{"joined"},
+		joinHandlers: []JoinHandler{nil},
+	}
+	it.current.joinObj = make([][]any, 1)
+	item := &benchPerfItem{}
+
+	for b.Loop() {
+		item.Joined = item.Joined[:0]
+		it.current.joinObj[0] = subitems
+		if err := it.join(0, 1, 0, item); err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += len(item.Joined)
+	}
+}
+
+func BenchmarkIteratorJoinable(b *testing.B) {
+	subitems := []any{
+		&benchPerfJoined{ID: 1, Name: "a"},
+		&benchPerfJoined{ID: 2, Name: "b"},
+		&benchPerfJoined{ID: 3, Name: "c"},
+	}
+	it := &Iterator{
+		query:        &Query{db: &reindexerImpl{}},
+		nsArray:      []nsArrayEntry{{reindexerNamespace: &reindexerNamespace{rtype: reflect.TypeFor[benchPerfJoinableItem]()}}, {reindexerNamespace: &reindexerNamespace{name: "bench_joined", rtype: reflect.TypeFor[benchPerfJoined]()}}},
+		joinToFields: []string{"joined"},
+		joinHandlers: []JoinHandler{nil},
+	}
+	it.current.joinObj = make([][]any, 1)
+
+	for b.Loop() {
+		item := &benchPerfJoinableItem{}
+		it.current.joinObj[0] = subitems
+		if err := it.join(0, 1, 0, item); err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += len(item.joinedSink)
+	}
+}
+
+func BenchmarkReflectParseIndexes(b *testing.B) {
+	t := reflect.TypeFor[benchPerfItem]()
+	for b.Loop() {
+		joined := make(map[string][]int)
+		indexes, err := parseIndexes(t, &joined)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += len(indexes) + len(joined)
+	}
+}
+
+func BenchmarkReflectParseSchema(b *testing.B) {
+	t := reflect.TypeFor[benchPerfItem]()
+	for b.Loop() {
+		benchPerfAnySink = parseSchema(t)
+	}
+}
+
+func BenchmarkReflectCjsonEncodeDecode(b *testing.B) {
+	item := &benchPerfItem{
+		ID:     42,
+		Age:    31,
+		Score:  123456789,
+		Price:  99.75,
+		Active: true,
+		Name:   "alice",
+		Tags:   []string{"a", "b", "c"},
+		Nums:   []int{1, 2, 3, 4, 5},
+		Vector: []float32{1, 2, 3, 4, 5, 6, 7, 8},
+		Nested: benchPerfNested{Code: 7, Labels: []string{"x", "y"}},
+		Payload: map[string]any{
+			"k1": "v1",
+			"k2": 42,
+		},
+	}
+	state := cjson.NewState()
+	enc := state.NewEncoder()
+	wr := cjson.NewPoolSerializer()
+	defer wr.Close()
+	if _, err := enc.Encode(item, wr); err != nil {
+		b.Fatal(err)
+	}
+	payload := append([]byte(nil), wr.Bytes()...)
+
+	b.Run("encode", func(b *testing.B) {
+		enc := state.NewEncoder()
+		ser := cjson.NewPoolSerializer()
+		defer ser.Close()
+		b.ReportAllocs()
+		for b.Loop() {
+			ser.Reset()
+			if _, err := enc.Encode(item, ser); err != nil {
+				b.Fatal(err)
+			}
+			benchPerfBytesSink = ser.Bytes()
+		}
+	})
+
+	b.Run("decode", func(b *testing.B) {
+		var out benchPerfItem
+		dec := state.NewDecoder(&out, nil)
+		defer dec.Finalize()
+		b.ReportAllocs()
+		for b.Loop() {
+			out = benchPerfItem{}
+			if err := dec.Decode(payload, &out); err != nil {
+				b.Fatal(err)
+			}
+			benchPerfAnySink = out
+		}
+	})
+}
+
+func BenchmarkReindexerPackItem(b *testing.B) {
+	item := &benchPerfItem{
+		ID:     42,
+		Age:    31,
+		Score:  123456789,
+		Price:  99.75,
+		Active: true,
+		Name:   "alice",
+		Tags:   []string{"a", "b", "c"},
+		Nums:   []int{1, 2, 3, 4, 5},
+		Vector: []float32{1, 2, 3, 4, 5, 6, 7, 8},
+		Nested: benchPerfNested{Code: 7, Labels: []string{"x", "y"}},
+	}
+	ns := &reindexerNamespace{
+		name:       "bench_items",
+		rtype:      reflect.TypeFor[benchPerfItem](),
+		cjsonState: cjson.NewState(),
+	}
+	ser := cjson.NewPoolSerializer()
+	defer ser.Close()
+	if _, _, err := packItem(ns, item, nil, ser); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ser.Reset()
+		format, token, err := packItem(ns, item, nil, ser)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += format + token + len(ser.Bytes())
+	}
+}
+
+func BenchmarkReindexerPackJSON(b *testing.B) {
+	ns := &reindexerNamespace{
+		name:       "bench_items",
+		rtype:      reflect.TypeFor[benchPerfItem](),
+		cjsonState: cjson.NewState(),
+	}
+	json := []byte(`{"id":42,"age":31,"name":"alice"}`)
+	ser := cjson.NewPoolSerializer()
+	defer ser.Close()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ser.Reset()
+		format, token, err := packItem(ns, nil, json, ser)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += format + token + len(ser.Bytes())
+	}
+}
+
+func BenchmarkQueryTypedVsReflectWhere(b *testing.B) {
+	keys := []int{1, 2, 3, 4, 5, 6, 7, 8}
+
+	b.Run("typed-WhereInt", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().WhereInt("id", SET, keys...)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("reflect-Where", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().Where("id", SET, keys)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+}
+
+func BenchmarkQuerySetObjectBytesVsStruct(b *testing.B) {
+	obj := benchPerfNested{Code: 7, Labels: []string{"hot", "path"}}
+	objJSON := []byte(`{"code":7,"labels":["hot","path"]}`)
+	objJSONArray := [][]byte{
+		[]byte(`{"code":1,"labels":["a"]}`),
+		[]byte(`{"code":2,"labels":["b"]}`),
+	}
+
+	b.Run("struct", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().SetObject("nested", obj)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("bytes", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().SetObject("nested", objJSON)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("nil", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().SetObject("nested", nil)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+
+	b.Run("bytes-array", func(b *testing.B) {
+		for b.Loop() {
+			q := newBenchPerfQuery().SetObject("nested", objJSONArray)
+			benchPerfBytesSink = q.ser.Bytes()
+			q.close()
+		}
+	})
+}
+
+func BenchmarkQueryWhereValueKinds(b *testing.B) {
+	values := []struct {
+		name string
+		val  any
+	}{
+		{"int", 42},
+		{"int64", int64(123456789)},
+		{"string", "alice"},
+		{"bool", true},
+		{"float64", 3.1415926535},
+		{"int-slice", []int{1, 2, 3, 4}},
+		{"string-slice", []string{"a", "b", "c"}},
+		{"interface-slice", []any{1, "a", true}},
+	}
+
+	for _, tc := range values {
+		b.Run(tc.name, func(b *testing.B) {
+			for b.Loop() {
+				q := newBenchPerfQuery().Where("field", EQ, tc.val)
+				benchPerfBytesSink = q.ser.Bytes()
+				q.close()
+			}
+		})
+	}
+}
+
+func BenchmarkReindexerModifyPreceptsSerialize(b *testing.B) {
+	ns := &reindexerNamespace{
+		name:       "bench_items",
+		rtype:      reflect.TypeFor[benchPerfItem](),
+		cjsonState: cjson.NewState(),
+	}
+	item := &benchPerfItem{ID: 42, Age: 31, Name: "alice"}
+	precepts := []string{"updated_at=NOW()", "serial=SERIAL()"}
+	ser := cjson.NewPoolSerializer()
+	defer ser.Close()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ser.Reset()
+		format, token, err := packItem(ns, item, nil, ser)
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchPerfIntSink += format + token + len(precepts) + len(ser.Bytes())
+	}
+}
+
+func BenchmarkQueryBuildAggregationLike(b *testing.B) {
+	for b.Loop() {
+		q := newBenchPerfQuery().
+			WhereInt("age", GE, 18).
+			AggregateSum("score").
+			AggregateAvg("price")
+		q.AggregateFacet("active", "age").
+			Limit(10).
+			Sort("count", true)
+		q.Select("id", "name", "score").
+			Functions("rank()").
+			EqualPosition("tags", "nums")
+		benchPerfBytesSink = q.ser.Bytes()
+		q.close()
+	}
+}
+
+func BenchmarkReflectIndexDefAppend(b *testing.B) {
+	defs := []bindings.IndexDef{
+		{Name: "id", JSONPaths: []string{"id"}, IndexType: "hash", FieldType: "int"},
+		{Name: "age", JSONPaths: []string{"age"}, IndexType: "tree", FieldType: "int"},
+	}
+	for b.Loop() {
+		out := make([]bindings.IndexDef, 0, len(defs))
+		for _, def := range defs {
+			if err := indexDefAppend(&out, def, true); err != nil {
+				b.Fatal(err)
+			}
+		}
+		benchPerfIntSink += len(out)
+	}
+}
+
+func benchRawQueryParamsBuf(withExtras bool) []byte {
+	ser := cjson.NewSerializer(nil)
+	ser.PutVarUInt(0)  // flags
+	ser.PutVarUInt(10) // totalcount
+	ser.PutVarUInt(10) // qcount
+	ser.PutVarUInt(10) // count
+	if withExtras {
+		ser.PutVarUInt(bindings.QueryResultAggregation)
+		agg := []byte(`[{"type":"sum","value":42}]`)
+		ser.PutUInt32(uint32(len(agg))).Write(agg)
+		ser.PutVarUInt(bindings.QueryResultExplain)
+		explain := []byte(`{"cost":1}`)
+		ser.PutUInt32(uint32(len(explain))).Write(explain)
+		ser.PutVarUInt(bindings.QueryResultIncarnationTags)
+		ser.PutVarUInt(4)
+		for shardID := range 4 {
+			ser.PutVarInt(int64(shardID))
+			ser.PutVarUInt(4)
+			for nsID := range 4 {
+				ser.PutVarInt(int64(shardID*100 + nsID))
+			}
+		}
+	}
+	ser.PutVarUInt(bindings.QueryResultEnd)
+	return append([]byte(nil), ser.Bytes()...)
+}
+
+func benchRawQueryParamsRankBuf() []byte {
+	ser := cjson.NewSerializer(nil)
+	ser.PutVarUInt(0)  // flags
+	ser.PutVarUInt(10) // totalcount
+	ser.PutVarUInt(10) // qcount
+	ser.PutVarUInt(10) // count
+	ser.PutVarUInt(bindings.QueryResultRankFormat)
+	ser.PutVarUInt(bindings.RankFormatSingleFloat)
+	ser.PutVarUInt(bindings.QueryResultEnd)
+	return append([]byte(nil), ser.Bytes()...)
+}
+
+func BenchmarkResultSerializerReadExtraResults(b *testing.B) {
+	b.Run("empty", func(b *testing.B) {
+		buf := benchRawQueryParamsBuf(false)
+		var params rawResultQueryParams
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := newSerializer(buf)
+			ser.readRawQueryParamsKeepExtras(&params)
+			benchPerfIntSink += params.count
+		}
+	})
+
+	b.Run("extras", func(b *testing.B) {
+		buf := benchRawQueryParamsBuf(true)
+		var params rawResultQueryParams
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := newSerializer(buf)
+			ser.readRawQueryParamsKeepExtras(&params)
+			benchPerfIntSink += len(params.aggResults) + len(params.explainResults) + len(params.nsIncarnationTags)
+		}
+	})
+
+	b.Run("rank-format", func(b *testing.B) {
+		buf := benchRawQueryParamsRankBuf()
+		var params rawResultQueryParams
+		b.ReportAllocs()
+		for b.Loop() {
+			ser := newSerializer(buf)
+			ser.readRawQueryParamsKeepExtras(&params)
+			if params.rankFormat != nil {
+				benchPerfIntSink += int(*params.rankFormat)
+			}
+		}
+	})
+}

--- a/result_serializer.go
+++ b/result_serializer.go
@@ -38,6 +38,8 @@ type resultSerializer struct {
 	rankFormat *uint64
 }
 
+var rankFormatSingleFloat = uint64(bindings.RankFormatSingleFloat)
+
 type updatePayloadTypeFunc func(nsid int)
 
 func newSerializer(buf []byte) resultSerializer {
@@ -86,6 +88,14 @@ func (s *resultSerializer) readRawtItemParams(shardId int) (v rawResultItemParam
 }
 
 func (s *resultSerializer) readRawQueryParamsKeepExtras(v *rawResultQueryParams, updatePayloadType ...updatePayloadTypeFunc) {
+	s.readRawQueryParamsInto(v, true, updatePayloadType...)
+}
+
+func (s *resultSerializer) readRawQueryParamsResetMissingExtras(v *rawResultQueryParams, updatePayloadType ...updatePayloadTypeFunc) {
+	s.readRawQueryParamsInto(v, false, updatePayloadType...)
+}
+
+func (s *resultSerializer) readRawQueryParamsInto(v *rawResultQueryParams, keepMissingTags bool, updatePayloadType ...updatePayloadTypeFunc) {
 
 	v.flags = int(s.GetVarUInt())
 	v.totalcount = int(s.GetVarUInt())
@@ -103,18 +113,19 @@ func (s *resultSerializer) readRawQueryParamsKeepExtras(v *rawResultQueryParams,
 			updatePayloadType[0](nsid)
 		}
 	}
-	s.readExtraResults(v)
+	s.readExtraResults(v, keepMissingTags)
 	s.flags = v.flags
 	s.rankFormat = v.rankFormat
 }
 
 func (s *resultSerializer) readRawQueryParams(updatePayloadType ...updatePayloadTypeFunc) (v rawResultQueryParams) {
-	s.readRawQueryParamsKeepExtras(&v, updatePayloadType...)
+	s.readRawQueryParamsResetMissingExtras(&v, updatePayloadType...)
 	return v
 }
 
-func (s *resultSerializer) readExtraResults(v *rawResultQueryParams) {
+func (s *resultSerializer) readExtraResults(v *rawResultQueryParams, keepMissingTags bool) {
 	firstAgg := true
+	hasIncarnationTags := false
 	v.shardingConfigVersion = -1
 	v.shardId = bindings.ShardingNotSet
 	for {
@@ -138,17 +149,38 @@ func (s *resultSerializer) readExtraResults(v *rawResultQueryParams) {
 		case bindings.QueryResultShardId:
 			v.shardId = int(s.GetVarUInt())
 		case bindings.QueryResultIncarnationTags:
-			shardsCnt := uint(s.GetVarUInt())
-			v.nsIncarnationTags = make(nsTagsMap)
+			hasIncarnationTags = true
+			shardsCnt := int(s.GetVarUInt())
+			if v.nsIncarnationTags == nil {
+				v.nsIncarnationTags = make(nsTagsMap, shardsCnt)
+			}
+			var seenBuf [8]int
+			seen := seenBuf[:0]
+			if shardsCnt > len(seenBuf) {
+				seen = make([]int, 0, shardsCnt)
+			}
 			for range shardsCnt {
 				shardID := int(s.GetVarInt())
-				nsCnt := uint(s.GetVarUInt())
+				nsCnt := int(s.GetVarUInt())
 				if nsCnt > 0 {
-					sl := make([]int64, nsCnt)
+					sl := v.nsIncarnationTags[shardID]
+					if cap(sl) < nsCnt {
+						sl = make([]int64, nsCnt)
+					} else {
+						sl = sl[:nsCnt]
+					}
 					for j := range nsCnt {
 						sl[j] = s.GetVarInt()
 					}
 					v.nsIncarnationTags[shardID] = sl
+					seen = append(seen, shardID)
+				} else {
+					delete(v.nsIncarnationTags, shardID)
+				}
+			}
+			for shardID := range v.nsIncarnationTags {
+				if !hasShardID(seen, shardID) {
+					delete(v.nsIncarnationTags, shardID)
 				}
 			}
 		case bindings.QueryResultRankFormat:
@@ -156,7 +188,21 @@ func (s *resultSerializer) readExtraResults(v *rawResultQueryParams) {
 			if format != bindings.RankFormatSingleFloat {
 				panic(fmt.Sprintf("unexpected rank format value: %d - only supported format is 0 (single float rank)", format))
 			}
-			v.rankFormat = &format
+			v.rankFormat = &rankFormatSingleFloat
 		}
 	}
+	if !keepMissingTags && !hasIncarnationTags && len(v.nsIncarnationTags) > 0 {
+		for shardID := range v.nsIncarnationTags {
+			delete(v.nsIncarnationTags, shardID)
+		}
+	}
+}
+
+func hasShardID(ids []int, shardID int) bool {
+	for _, id := range ids {
+		if id == shardID {
+			return true
+		}
+	}
+	return false
 }

--- a/tx.go
+++ b/tx.go
@@ -453,7 +453,7 @@ func (tx *Tx) modifyInternal(item any, json []byte, mode int, precepts ...string
 			format := 0
 			stateToken := 0
 
-			if format, stateToken, err = packItem(tx.ns, item, json, ser); err != nil {
+			if format, stateToken, _, err = packItem(tx.ns, item, json, ser); err != nil {
 				return err
 			}
 
@@ -547,7 +547,7 @@ func (tx *Tx) modifyInternalAsync(item any, json []byte, mode int, cmpl bindings
 	format := 0
 	stateToken := 0
 
-	if format, stateToken, err = packItem(tx.ns, item, json, ser); err != nil {
+	if format, stateToken, _, err = packItem(tx.ns, item, json, ser); err != nil {
 		internalCmpl(nil, err)
 		return err
 	}


### PR DESCRIPTION
## Summary

This PR optimizes several Go hot paths in Reindexer without changing public APIs, wire protocol, iterator ownership semantics, or user-visible error messages.

The main focus is reducing latency and allocations in `cjson`, query construction, iterator join handling, reflection metadata parsing, and result metadata decoding.

## Changes

- Optimized `cjson` serializer and encoder hot paths:
  - faster varint encode/decode paths;
  - direct fixed-size float reads/writes;
  - `SkipVString` for skipped string payloads;
  - `PutVString` without temporary `[]byte` conversion;
  - encoder cache lookup that avoids rebuilding field-path slices on warm encode paths;
  - faster UUID parse fast path with fallback for validation/error behavior.

- Optimized query-building paths:
  - typed fast paths for common `Where` and `Set` value kinds;
  - lower overhead for `SetObject` byte payloads;
  - reuse of aggregate facet request storage;
  - avoid debug trace work when debug tracing is disabled.

- Optimized iterator/result parsing paths:
  - reduce allocations when reading extra result metadata;
  - reuse/clear `nsIncarnationTags`;
  - avoid unnecessary allocations for missing/empty extras;
  - pre-size joined result slices in reflection-heavy iterator paths.

- Optimized reflection/schema metadata paths:
  - cache parsed schema/index metadata for repeated type registration paths.

- Added focused benchmarks for:
  - cjson encoder/serializer/UUID/slice paths;
  - query builder paths;
  - iterator join paths;
  - reflection schema parsing;
  - result serializer extras;
  - write/pack item paths.

- Restored/fixed Windows NSIS setup in CI.

## Performance

Compared:
`global-before-cjson-encoder` → `global-after-cjson-encoder`

- global geomean time: `134.9µs -> 128.8µs` (`-4.48%`)
- global geomean B/op: `3132.7 -> 2798.7` (`-18.67%`)
- global geomean allocs/op: `38.67 -> 35.26` (`-8.80%`)

Notable rows:

- `BenchmarkCJsonEncode`: `1.696µs -> 1.607µs` (`-5.25%`)
- `BenchmarkCJsonEncode` B/op: `7 -> 0`
- `BenchmarkCJsonEncode` allocs/op: `0 -> 0`

The full global benchmark improved overall in this comparison: geomean time is down by `4.48%`, geomean `B/op` is down by `18.67%`, and geomean `allocs/op` is down by `8.80%`.


Some global query benchmarks are noisy between runs, so this PR only claims the stable focused improvements and the observed allocation reduction